### PR TITLE
Changes to compile under 90X.

### DIFF
--- a/interface/HcalTupleMaker_HcalDigiAlgorithm.h
+++ b/interface/HcalTupleMaker_HcalDigiAlgorithm.h
@@ -31,37 +31,37 @@ public:
   void setFilterChannels (bool b ) { m_filterChannels = b; }
   void setChannelFilterList ( std::vector<edm::ParameterSet> vps ) { m_channelFilterList = vps; }
   
-  std::auto_ptr<std::vector<int> > ieta;           
-  std::auto_ptr<std::vector<int> > iphi;           
-  std::auto_ptr<std::vector<float> > eta;           
-  std::auto_ptr<std::vector<float> > phi;          
-  std::auto_ptr<std::vector<int> > subdet;          
-  std::auto_ptr<std::vector<int> > depth;          
-  std::auto_ptr<std::vector<int> > presamples;     
-  std::auto_ptr<std::vector<int> > size;           
-  std::auto_ptr<std::vector<int> > fiberIdleOffset;
-  std::auto_ptr<std::vector<int> > electronicsId;
-  std::auto_ptr<std::vector<int> > rawId;
+  std::unique_ptr<std::vector<int> > ieta;
+  std::unique_ptr<std::vector<int> > iphi;
+  std::unique_ptr<std::vector<float> > eta;
+  std::unique_ptr<std::vector<float> > phi;
+  std::unique_ptr<std::vector<int> > subdet;
+  std::unique_ptr<std::vector<int> > depth;
+  std::unique_ptr<std::vector<int> > presamples;
+  std::unique_ptr<std::vector<int> > size;
+  std::unique_ptr<std::vector<int> > fiberIdleOffset;
+  std::unique_ptr<std::vector<int> > electronicsId;
+  std::unique_ptr<std::vector<int> > rawId;
 
-  std::auto_ptr<std::vector<std::vector<int  > > > dv;	     	
-  std::auto_ptr<std::vector<std::vector<int  > > > er;	     	
-  std::auto_ptr<std::vector<std::vector<int  > > > raw;	     	
-  std::auto_ptr<std::vector<std::vector<int  > > > adc;	     	
-  std::auto_ptr<std::vector<std::vector<float> > > nomFC;    	
-  std::auto_ptr<std::vector<std::vector<int  > > > fiber;    	
-  std::auto_ptr<std::vector<std::vector<int  > > > fiberChan;	
-  std::auto_ptr<std::vector<std::vector<int  > > > capid;   
-  std::auto_ptr<std::vector<std::vector<int  > > > ladc;   
+  std::unique_ptr<std::vector<std::vector<int  > > > dv;
+  std::unique_ptr<std::vector<std::vector<int  > > > er;
+  std::unique_ptr<std::vector<std::vector<int  > > > raw;
+  std::unique_ptr<std::vector<std::vector<int  > > > adc;
+  std::unique_ptr<std::vector<std::vector<float> > > nomFC;
+  std::unique_ptr<std::vector<std::vector<int  > > > fiber;
+  std::unique_ptr<std::vector<std::vector<int  > > > fiberChan;
+  std::unique_ptr<std::vector<std::vector<int  > > > capid;
+  std::unique_ptr<std::vector<std::vector<int  > > > ladc;
 						                
-  std::auto_ptr<std::vector<std::vector<float> > > allFC;    	
-  std::auto_ptr<std::vector<std::vector<float> > > pedFC;    	
-  std::auto_ptr<std::vector<std::vector<float> > > gain;    	
-  std::auto_ptr<std::vector<std::vector<float> > > rcgain;    	
-  std::auto_ptr<std::vector<std::vector<float> > > FC;		
-  std::auto_ptr<std::vector<std::vector<float> > > energy;    	
+  std::unique_ptr<std::vector<std::vector<float> > > allFC;
+  std::unique_ptr<std::vector<std::vector<float> > > pedFC;
+  std::unique_ptr<std::vector<std::vector<float> > > gain;
+  std::unique_ptr<std::vector<std::vector<float> > > rcgain;
+  std::unique_ptr<std::vector<std::vector<float> > > FC;
+  std::unique_ptr<std::vector<std::vector<float> > > energy;
 						                
-  std::auto_ptr<std::vector<float> > rec_energy;    
-  std::auto_ptr<std::vector<float> > rec_time;    
+  std::unique_ptr<std::vector<float> > rec_energy;
+  std::unique_ptr<std::vector<float> > rec_time;
   
   template <class DigiCollection, class RecoCollection, class DetIdClass, class DetIdClassWrapper > 
   void run ( const HcalDbService    & conditions,  

--- a/interface/HcalTupleMaker_HcalDigis.h
+++ b/interface/HcalTupleMaker_HcalDigis.h
@@ -146,72 +146,72 @@ public:
 protected:
   
   void loadAlgo(){
-    algo.ieta            = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.iphi            = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.eta             = std::auto_ptr<std::vector<float> >               ( new std::vector<float> ());
-    algo.phi             = std::auto_ptr<std::vector<float> >               ( new std::vector<float> ());
-    algo.depth           = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.subdet          = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.presamples      = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.size            = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.fiberIdleOffset = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.electronicsId   = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.rawId           = std::auto_ptr<std::vector<int> >                 ( new std::vector<int>   ());
-    algo.rec_energy      = std::auto_ptr<std::vector<float> >               ( new std::vector<float> ());  
-    algo.rec_time        = std::auto_ptr<std::vector<float> >               ( new std::vector<float> ());  
-    
-    algo.dv 	         = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    algo.er 	         = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    algo.raw 	         = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    algo.adc 	         = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    algo.nomFC           = std::auto_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());  
-    algo.fiber           = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    algo.fiberChan       = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    algo.capid           = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    algo.ladc            = std::auto_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());  
-    
-    algo.allFC           = std::auto_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());  
-    algo.pedFC           = std::auto_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());  
-    algo.gain            = std::auto_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());  
-    algo.rcgain          = std::auto_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());  
-    algo.FC 	         = std::auto_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());  
-    algo.energy          = std::auto_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());  
+    algo.ieta            = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.iphi            = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.eta             = std::unique_ptr<std::vector<float> >               ( new std::vector<float> ());
+    algo.phi             = std::unique_ptr<std::vector<float> >               ( new std::vector<float> ());
+    algo.depth           = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.subdet          = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.presamples      = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.size            = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.fiberIdleOffset = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.electronicsId   = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.rawId           = std::unique_ptr<std::vector<int> >                 ( new std::vector<int>   ());
+    algo.rec_energy      = std::unique_ptr<std::vector<float> >               ( new std::vector<float> ());
+    algo.rec_time        = std::unique_ptr<std::vector<float> >               ( new std::vector<float> ());
+
+    algo.dv 	         = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+    algo.er 	         = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+    algo.raw 	         = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+    algo.adc 	         = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+    algo.nomFC           = std::unique_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());
+    algo.fiber           = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+    algo.fiberChan       = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+    algo.capid           = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+    algo.ladc            = std::unique_ptr<std::vector<std::vector<int  > > > ( new std::vector<std::vector<int  > > ());
+
+    algo.allFC           = std::unique_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());
+    algo.pedFC           = std::unique_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());
+    algo.gain            = std::unique_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());
+    algo.rcgain          = std::unique_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());
+    algo.FC 	         = std::unique_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());
+    algo.energy          = std::unique_ptr<std::vector<std::vector<float> > > ( new std::vector<std::vector<float> > ());
     
   }
 
   void dumpAlgo ( edm::Event & iEvent ){
 
-    iEvent.put ( algo.ieta            , m_prefix + "IEta"            + m_suffix );
-    iEvent.put ( algo.iphi            , m_prefix + "IPhi"            + m_suffix );
-    iEvent.put ( algo.eta             , m_prefix + "Eta"             + m_suffix );
-    iEvent.put ( algo.phi             , m_prefix + "Phi"             + m_suffix );
-    iEvent.put ( algo.depth           , m_prefix + "Depth"           + m_suffix );
-    iEvent.put ( algo.subdet          , m_prefix + "Subdet"          + m_suffix );
-    iEvent.put ( algo.presamples      , m_prefix + "Presamples"      + m_suffix );
-    iEvent.put ( algo.size            , m_prefix + "Size"            + m_suffix );
-    iEvent.put ( algo.fiberIdleOffset , m_prefix + "FiberIdleOffset" + m_suffix );
-    iEvent.put ( algo.electronicsId   , m_prefix + "ElectronicsID"   + m_suffix );
-    iEvent.put ( algo.rawId           , m_prefix + "RawID"           + m_suffix );
+    iEvent.put( move(algo.ieta            ), m_prefix + "IEta"            + m_suffix );
+    iEvent.put( move(algo.iphi            ), m_prefix + "IPhi"            + m_suffix );
+    iEvent.put( move(algo.eta             ), m_prefix + "Eta"             + m_suffix );
+    iEvent.put( move(algo.phi             ), m_prefix + "Phi"             + m_suffix );
+    iEvent.put( move(algo.depth           ), m_prefix + "Depth"           + m_suffix );
+    iEvent.put( move(algo.subdet          ), m_prefix + "Subdet"          + m_suffix );
+    iEvent.put( move(algo.presamples      ), m_prefix + "Presamples"      + m_suffix );
+    iEvent.put( move(algo.size            ), m_prefix + "Size"            + m_suffix );
+    iEvent.put( move(algo.fiberIdleOffset ), m_prefix + "FiberIdleOffset" + m_suffix );
+    iEvent.put( move(algo.electronicsId   ), m_prefix + "ElectronicsID"   + m_suffix );
+    iEvent.put( move(algo.rawId           ), m_prefix + "RawID"           + m_suffix );
    
-    iEvent.put ( algo.dv              , m_prefix + "DV"              + m_suffix );	     	
-    iEvent.put ( algo.er              , m_prefix + "ER"              + m_suffix );	     	
-    iEvent.put ( algo.raw  	     , m_prefix + "Raw"             + m_suffix );	     	
-    iEvent.put ( algo.adc   	     , m_prefix + "ADC"             + m_suffix );	     	
-    iEvent.put ( algo.nomFC           , m_prefix + "NomFC"           + m_suffix );    	
-    iEvent.put ( algo.fiber           , m_prefix + "Fiber"           + m_suffix );    	
-    iEvent.put ( algo.fiberChan       , m_prefix + "FiberChan"       + m_suffix );	
-    iEvent.put ( algo.capid           , m_prefix + "CapID"           + m_suffix );    	
-    iEvent.put ( algo.ladc   	     , m_prefix + "LADC"            + m_suffix );	     	
+    iEvent.put( move(algo.dv              ), m_prefix + "DV"              + m_suffix );
+    iEvent.put( move(algo.er              ), m_prefix + "ER"              + m_suffix );
+    iEvent.put( move(algo.raw  	          ), m_prefix + "Raw"             + m_suffix );
+    iEvent.put( move(algo.adc   	  ), m_prefix + "ADC"             + m_suffix );
+    iEvent.put( move(algo.nomFC           ), m_prefix + "NomFC"           + m_suffix );
+    iEvent.put( move(algo.fiber           ), m_prefix + "Fiber"           + m_suffix );
+    iEvent.put( move(algo.fiberChan       ), m_prefix + "FiberChan"       + m_suffix );
+    iEvent.put( move(algo.capid           ), m_prefix + "CapID"           + m_suffix );
+    iEvent.put( move(algo.ladc   	  ), m_prefix + "LADC"            + m_suffix );
    
-    iEvent.put ( algo.allFC           , m_prefix + "AllFC"           + m_suffix );    	
-    iEvent.put ( algo.pedFC           , m_prefix + "PedFC"           + m_suffix );    	
-    iEvent.put ( algo.gain            , m_prefix + "Gain"            + m_suffix );    	
-    iEvent.put ( algo.rcgain          , m_prefix + "RCGain"          + m_suffix );    	
-    iEvent.put ( algo.FC 	     , m_prefix + "FC"              + m_suffix );		
-    iEvent.put ( algo.energy          , m_prefix + "Energy"          + m_suffix );    	
-   
-    iEvent.put ( algo.rec_energy      , m_prefix + "RecEnergy"       + m_suffix );    	
-    iEvent.put ( algo.rec_time        , m_prefix + "RecTime"         + m_suffix );      
+    iEvent.put( move(algo.allFC           ), m_prefix + "AllFC"           + m_suffix );
+    iEvent.put( move(algo.pedFC           ), m_prefix + "PedFC"           + m_suffix );
+    iEvent.put( move(algo.gain            ), m_prefix + "Gain"            + m_suffix );
+    iEvent.put( move(algo.rcgain          ), m_prefix + "RCGain"          + m_suffix );
+    iEvent.put( move(algo.FC 	          ), m_prefix + "FC"              + m_suffix );
+    iEvent.put( move(algo.energy          ), m_prefix + "Energy"          + m_suffix );
+
+    iEvent.put( move(algo.rec_energy      ), m_prefix + "RecEnergy"       + m_suffix );
+    iEvent.put( move(algo.rec_time        ), m_prefix + "RecTime"         + m_suffix );
    
   }
 };

--- a/interface/HcalTupleMaker_HcalRecHitAlgorithm.h
+++ b/interface/HcalTupleMaker_HcalRecHitAlgorithm.h
@@ -21,17 +21,17 @@ class HcalTupleMaker_HcalRecHitAlgorithm {
 
   void run ();
   
-  std::auto_ptr<std::vector<int  > > ieta;           
-  std::auto_ptr<std::vector<int  > > iphi;           
-  std::auto_ptr<std::vector<float> > eta;           
-  std::auto_ptr<std::vector<float> > phi;           
-  std::auto_ptr<std::vector<int  > > depth;          
-  std::auto_ptr<std::vector<int  > > rbxid;
-  std::auto_ptr<std::vector<int  > > hpdid;
-  std::auto_ptr<std::vector<float> > energy;    
-  std::auto_ptr<std::vector<float> > time;    
-  std::auto_ptr<std::vector<int  > > flags;           
-  std::auto_ptr<std::vector<int  > > aux;     
+  std::unique_ptr<std::vector<int  > > ieta;
+  std::unique_ptr<std::vector<int  > > iphi;
+  std::unique_ptr<std::vector<float> > eta;
+  std::unique_ptr<std::vector<float> > phi;
+  std::unique_ptr<std::vector<int  > > depth;
+  std::unique_ptr<std::vector<int  > > rbxid;
+  std::unique_ptr<std::vector<int  > > hpdid;
+  std::unique_ptr<std::vector<float> > energy;
+  std::unique_ptr<std::vector<float> > time;
+  std::unique_ptr<std::vector<int  > > flags;
+  std::unique_ptr<std::vector<int  > > aux;
   
   template <class RecoCollection > 
     void run ( const RecoCollection & recos, const CaloGeometry & geometry ){

--- a/interface/HcalTupleMaker_HcalRecHits.h
+++ b/interface/HcalTupleMaker_HcalRecHits.h
@@ -87,31 +87,31 @@ class HcalTupleMaker_HcalRecHits : public edm::EDProducer {
  protected:
 
   void loadAlgo(){
-    algo.ieta   = std::auto_ptr<std::vector<int  > > ( new std::vector<int  > ());
-    algo.iphi   = std::auto_ptr<std::vector<int  > > ( new std::vector<int  > ());
-    algo.eta    = std::auto_ptr<std::vector<float> > ( new std::vector<float> ());
-    algo.phi    = std::auto_ptr<std::vector<float> > ( new std::vector<float> ());
-    algo.depth  = std::auto_ptr<std::vector<int  > > ( new std::vector<int  > ());
-    algo.rbxid  = std::auto_ptr<std::vector<int  > > ( new std::vector<int  > ());
-    algo.hpdid  = std::auto_ptr<std::vector<int  > > ( new std::vector<int  > ());
-    algo.flags  = std::auto_ptr<std::vector<int  > > ( new std::vector<int  > ());
-    algo.aux    = std::auto_ptr<std::vector<int  > > ( new std::vector<int  > ());
-    algo.energy = std::auto_ptr<std::vector<float> > ( new std::vector<float> ());
-    algo.time   = std::auto_ptr<std::vector<float> > ( new std::vector<float> ());
+    algo.ieta   = std::unique_ptr<std::vector<int  > > ( new std::vector<int  > ());
+    algo.iphi   = std::unique_ptr<std::vector<int  > > ( new std::vector<int  > ());
+    algo.eta    = std::unique_ptr<std::vector<float> > ( new std::vector<float> ());
+    algo.phi    = std::unique_ptr<std::vector<float> > ( new std::vector<float> ());
+    algo.depth  = std::unique_ptr<std::vector<int  > > ( new std::vector<int  > ());
+    algo.rbxid  = std::unique_ptr<std::vector<int  > > ( new std::vector<int  > ());
+    algo.hpdid  = std::unique_ptr<std::vector<int  > > ( new std::vector<int  > ());
+    algo.flags  = std::unique_ptr<std::vector<int  > > ( new std::vector<int  > ());
+    algo.aux    = std::unique_ptr<std::vector<int  > > ( new std::vector<int  > ());
+    algo.energy = std::unique_ptr<std::vector<float> > ( new std::vector<float> ());
+    algo.time   = std::unique_ptr<std::vector<float> > ( new std::vector<float> ());
   }
   
   void dumpAlgo( edm::Event & iEvent ){
-    iEvent.put ( algo.ieta   , m_prefix + "IEta"   + m_suffix );
-    iEvent.put ( algo.iphi   , m_prefix + "IPhi"   + m_suffix );
-    iEvent.put ( algo.eta    , m_prefix + "Eta"    + m_suffix );
-    iEvent.put ( algo.phi    , m_prefix + "Phi"    + m_suffix );
-    iEvent.put ( algo.depth  , m_prefix + "Depth"  + m_suffix );
-    iEvent.put ( algo.rbxid  , m_prefix + "RBXid"  + m_suffix );
-    iEvent.put ( algo.hpdid  , m_prefix + "HPDid"  + m_suffix );
-    iEvent.put ( algo.flags  , m_prefix + "Flags"  + m_suffix );
-    iEvent.put ( algo.aux    , m_prefix + "Aux"    + m_suffix );
-    iEvent.put ( algo.energy , m_prefix + "Energy" + m_suffix );
-    iEvent.put ( algo.time   , m_prefix + "Time"   + m_suffix );
+    iEvent.put( move(algo.ieta   ), m_prefix + "IEta"   + m_suffix );
+    iEvent.put( move(algo.iphi   ), m_prefix + "IPhi"   + m_suffix );
+    iEvent.put( move(algo.eta    ), m_prefix + "Eta"    + m_suffix );
+    iEvent.put( move(algo.phi    ), m_prefix + "Phi"    + m_suffix );
+    iEvent.put( move(algo.depth  ), m_prefix + "Depth"  + m_suffix );
+    iEvent.put( move(algo.rbxid  ), m_prefix + "RBXid"  + m_suffix );
+    iEvent.put( move(algo.hpdid  ), m_prefix + "HPDid"  + m_suffix );
+    iEvent.put( move(algo.flags  ), m_prefix + "Flags"  + m_suffix );
+    iEvent.put( move(algo.aux    ), m_prefix + "Aux"    + m_suffix );
+    iEvent.put( move(algo.energy ), m_prefix + "Energy" + m_suffix );
+    iEvent.put( move(algo.time   ), m_prefix + "Time"   + m_suffix );
   }
   
   

--- a/plugins/HcalCosmicDigisProducer.cc
+++ b/plugins/HcalCosmicDigisProducer.cc
@@ -33,9 +33,9 @@ void HcalCosmicDigisProducer::produce(edm::Event& iEvent, const edm::EventSetup&
   iEvent.getByToken(hoToken_,hoInputDigis);
   iEvent.getByToken(hfToken_,hfInputDigis);
 
-  std::auto_ptr<HBHEDigiCollection> hbheOutputDigis(new HBHEDigiCollection()); 
-  std::auto_ptr<HODigiCollection>   hoOutputDigis  (new HODigiCollection());
-  std::auto_ptr<HFDigiCollection>   hfOutputDigis  (new HFDigiCollection());
+  std::unique_ptr<HBHEDigiCollection> hbheOutputDigis(new HBHEDigiCollection());
+  std::unique_ptr<HODigiCollection>   hoOutputDigis  (new HODigiCollection());
+  std::unique_ptr<HFDigiCollection>   hfOutputDigis  (new HFDigiCollection());
 
   reco::TrackCollection::const_iterator recoTrack     = recoTracks -> begin();
   reco::TrackCollection::const_iterator recoTrack_end = recoTracks -> end();
@@ -74,9 +74,9 @@ void HcalCosmicDigisProducer::produce(edm::Event& iEvent, const edm::EventSetup&
     }
   }
 
-  iEvent.put(hbheOutputDigis);
-  iEvent.put(hoOutputDigis  );
-  iEvent.put(hfOutputDigis  );
+  iEvent.put(move(hbheOutputDigis));
+  iEvent.put(move(hoOutputDigis  ));
+  iEvent.put(move(hfOutputDigis  ));
   
 }
 

--- a/plugins/HcalL1JetDigisProducer.cc
+++ b/plugins/HcalL1JetDigisProducer.cc
@@ -47,9 +47,9 @@ void HcalL1JetDigisProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   iEvent.getByToken(tp_digi_token_  , hcalInputTPs  );
 
   // Declare output collections
-  std::auto_ptr<HBHEDigiCollection>         hbheOutputDigis(new HBHEDigiCollection()); 
-  std::auto_ptr<HFDigiCollection>           hfOutputDigis  (new HFDigiCollection());
-  std::auto_ptr<HcalTrigPrimDigiCollection> hcalOutputTPs  (new HcalTrigPrimDigiCollection());
+  std::unique_ptr<HBHEDigiCollection>         hbheOutputDigis(new HBHEDigiCollection());
+  std::unique_ptr<HFDigiCollection>           hfOutputDigis  (new HFDigiCollection());
+  std::unique_ptr<HcalTrigPrimDigiCollection> hcalOutputTPs  (new HcalTrigPrimDigiCollection());
 
   // Get iterators for various input collections
   HcalTrigPrimDigiCollection::const_iterator iTP;
@@ -135,9 +135,9 @@ void HcalL1JetDigisProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   } // End loop over jet collections
 
   // Put new collections into the event
-  iEvent.put(hcalOutputTPs  );
-  iEvent.put(hbheOutputDigis);
-  iEvent.put(hfOutputDigis  );
+  iEvent.put(move(hcalOutputTPs)  );
+  iEvent.put(move(hbheOutputDigis));
+  iEvent.put(move(hfOutputDigis)  );
   
 }
 

--- a/plugins/HcalTupleMaker_CaloJetMet.cc
+++ b/plugins/HcalTupleMaker_CaloJetMet.cc
@@ -43,35 +43,35 @@ HcalTupleMaker_CaloJetMet::HcalTupleMaker_CaloJetMet(const edm::ParameterSet& iC
 }
 
 void HcalTupleMaker_CaloJetMet::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
-  std::auto_ptr<std::vector<double> >            ebet         ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            eeet         ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            hbet         ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            heet         ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            hfet         ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            ebsume       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            eesume       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            hbsume       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            hesume       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            ebsumet      ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            eesumet      ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            hbsumet      ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            hesumet      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            ebet         ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            eeet         ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            hbet         ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            heet         ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            hfet         ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            ebsume       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            eesume       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            hbsume       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            hesume       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            ebsumet      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            eesumet      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            hbsumet      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            hesumet      ( new std::vector<double>           ());
   //
-  std::auto_ptr<std::vector<double> >            nominalmet   ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            nominalmet   ( new std::vector<double>           ());
   //
-  std::auto_ptr<std::vector<double> >            jeteta       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jetpt        ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jetphi       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jethadhb     ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jethadhe     ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jethadhf     ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jetemeb      ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jetemee      ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jetemhf      ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jetemfrac    ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            jethadfrac   ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<int> >               jetn90       ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<int> >               jetn60       ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<double> >            jeteta       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jetpt        ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jetphi       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jethadhb     ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jethadhe     ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jethadhf     ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jetemeb      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jetemee      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jetemhf      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jetemfrac    ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            jethadfrac   ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<int> >               jetn90       ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<int> >               jetn60       ( new std::vector<int>              ());
  
   edm::Handle<HBHERecHitCollection> hRecHits;
   iEvent.getByToken(recoInputToken, hRecHits);
@@ -147,35 +147,35 @@ void HcalTupleMaker_CaloJetMet::produce(edm::Event& iEvent, const edm::EventSetu
   hbsumet -> push_back( HBSumET );
   hesumet -> push_back( HESumET );
 
-  iEvent.put(ebet       , prefix + "EBET"            + suffix );
-  iEvent.put(eeet       , prefix + "EEET"            + suffix );
-  iEvent.put(hbet       , prefix + "HBET"            + suffix );
-  iEvent.put(heet       , prefix + "HEET"            + suffix );
-  iEvent.put(hfet       , prefix + "HFET"            + suffix );
-  iEvent.put(ebsume     , prefix + "EBSumE"          + suffix );  
-  iEvent.put(eesume     , prefix + "EESumE"          + suffix );  
-  iEvent.put(hbsume     , prefix + "HBSumE"          + suffix );  
-  iEvent.put(hesume     , prefix + "HESumE"          + suffix );  
-  iEvent.put(ebsumet    , prefix + "EBSumET"         + suffix );  
-  iEvent.put(eesumet    , prefix + "EESumET"         + suffix );  
-  iEvent.put(hbsumet    , prefix + "HBSumET"         + suffix );  
-  iEvent.put(hesumet    , prefix + "HESumET"         + suffix );  
+  iEvent.put(move(ebet       ), prefix + "EBET"            + suffix );
+  iEvent.put(move(eeet       ), prefix + "EEET"            + suffix );
+  iEvent.put(move(hbet       ), prefix + "HBET"            + suffix );
+  iEvent.put(move(heet       ), prefix + "HEET"            + suffix );
+  iEvent.put(move(hfet       ), prefix + "HFET"            + suffix );
+  iEvent.put(move(ebsume     ), prefix + "EBSumE"          + suffix );
+  iEvent.put(move(eesume     ), prefix + "EESumE"          + suffix );
+  iEvent.put(move(hbsume     ), prefix + "HBSumE"          + suffix );
+  iEvent.put(move(hesume     ), prefix + "HESumE"          + suffix );
+  iEvent.put(move(ebsumet    ), prefix + "EBSumET"         + suffix );
+  iEvent.put(move(eesumet    ), prefix + "EESumET"         + suffix );
+  iEvent.put(move(hbsumet    ), prefix + "HBSumET"         + suffix );
+  iEvent.put(move(hesumet    ), prefix + "HESumET"         + suffix );
   //
-  iEvent.put(nominalmet , prefix + "NominalMET"      + suffix );  
+  iEvent.put(move(nominalmet ), prefix + "NominalMET"      + suffix );
   //
-  iEvent.put(jeteta     , prefix + "JetEta"         + suffix );  
-  iEvent.put(jetpt      , prefix + "JetPt"          + suffix );  
-  iEvent.put(jetphi     , prefix + "JetPhi"         + suffix );  
-  iEvent.put(jethadhb   , prefix + "JetHadHB"       + suffix );  
-  iEvent.put(jethadhe   , prefix + "JetHadHE"       + suffix );  
-  iEvent.put(jethadhf   , prefix + "JetHadHF"       + suffix );  
-  iEvent.put(jetemeb    , prefix + "JetEMEB"        + suffix );  
-  iEvent.put(jetemee    , prefix + "JetEMEE"        + suffix );  
-  iEvent.put(jetemhf    , prefix + "JetEMHF"        + suffix );  
-  iEvent.put(jetemfrac  , prefix + "JetEMFrac"      + suffix );
-  iEvent.put(jethadfrac , prefix + "JetHadFrac"     + suffix );
-  iEvent.put(jetn90     , prefix + "JetN90"         + suffix );
-  iEvent.put(jetn60     , prefix + "JetN60"         + suffix );
+  iEvent.put(move(jeteta     ), prefix + "JetEta"         + suffix );
+  iEvent.put(move(jetpt      ), prefix + "JetPt"          + suffix );
+  iEvent.put(move(jetphi     ), prefix + "JetPhi"         + suffix );
+  iEvent.put(move(jethadhb   ), prefix + "JetHadHB"       + suffix );
+  iEvent.put(move(jethadhe   ), prefix + "JetHadHE"       + suffix );
+  iEvent.put(move(jethadhf   ), prefix + "JetHadHF"       + suffix );
+  iEvent.put(move(jetemeb    ), prefix + "JetEMEB"        + suffix );
+  iEvent.put(move(jetemee    ), prefix + "JetEMEE"        + suffix );
+  iEvent.put(move(jetemhf    ), prefix + "JetEMHF"        + suffix );
+  iEvent.put(move(jetemfrac  ), prefix + "JetEMFrac"      + suffix );
+  iEvent.put(move(jethadfrac ), prefix + "JetHadFrac"     + suffix );
+  iEvent.put(move(jetn90     ), prefix + "JetN90"         + suffix );
+  iEvent.put(move(jetn60     ), prefix + "JetN60"         + suffix );
 }
 
 void HcalTupleMaker_CaloJetMet::CalculateTotalEnergiesHBHE(const HBHERecHitCollection &RecHits){

--- a/plugins/HcalTupleMaker_Event.cc
+++ b/plugins/HcalTupleMaker_Event.cc
@@ -13,18 +13,18 @@ HcalTupleMaker_Event::HcalTupleMaker_Event(const edm::ParameterSet& iConfig) {
 void HcalTupleMaker_Event::
 produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-  std::auto_ptr<unsigned int >  run   ( new unsigned int(iEvent.id().run()        ) );
-  std::auto_ptr<unsigned int >  event ( new unsigned int(iEvent.id().event()      ) );
-  std::auto_ptr<unsigned int >  ls    ( new unsigned int(iEvent.luminosityBlock() ) );
+  std::unique_ptr<unsigned int >  run   ( new unsigned int(iEvent.id().run()        ) );
+  std::unique_ptr<unsigned int >  event ( new unsigned int(iEvent.id().event()      ) );
+  std::unique_ptr<unsigned int >  ls    ( new unsigned int(iEvent.luminosityBlock() ) );
 
   edm::EventBase const & eventbase = iEvent;
-  std::auto_ptr<unsigned int >  bx    ( new unsigned int(eventbase.bunchCrossing() ) );
-  std::auto_ptr<unsigned int >  orbit ( new unsigned int(eventbase.orbitNumber()   ) );
+  std::unique_ptr<unsigned int >  bx    ( new unsigned int(eventbase.bunchCrossing() ) );
+  std::unique_ptr<unsigned int >  orbit ( new unsigned int(eventbase.orbitNumber()   ) );
   
-  iEvent.put( run,   "run"   );
-  iEvent.put( event, "event" );
-  iEvent.put( ls   , "ls"    );
-  iEvent.put( bx   , "bx"    );
-  iEvent.put( orbit, "orbit" );
+  iEvent.put(move( run  ), "run"   );
+  iEvent.put(move( event), "event" );
+  iEvent.put(move( ls   ), "ls"    );
+  iEvent.put(move( bx   ), "bx"    );
+  iEvent.put(move( orbit), "orbit" );
 
 }

--- a/plugins/HcalTupleMaker_FEDs.cc
+++ b/plugins/HcalTupleMaker_FEDs.cc
@@ -24,10 +24,10 @@ HcalTupleMaker_FEDs::HcalTupleMaker_FEDs(const edm::ParameterSet& iConfig) :
 void HcalTupleMaker_FEDs::
 produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-  std::auto_ptr<std::vector<int> > number ( new std::vector<int> () );
-  std::auto_ptr<std::vector<int> > my_size( new std::vector<int> () );
-  std::auto_ptr<std::vector<int> > bcn    ( new std::vector<int> () );
-  std::auto_ptr<std::vector<int> > orn    ( new std::vector<int> () );
+  std::unique_ptr<std::vector<int> > number ( new std::vector<int> () );
+  std::unique_ptr<std::vector<int> > my_size( new std::vector<int> () );
+  std::unique_ptr<std::vector<int> > bcn    ( new std::vector<int> () );
+  std::unique_ptr<std::vector<int> > orn    ( new std::vector<int> () );
   
   edm::Handle<FEDRawDataCollection> rawData;
   if (iEvent.getByToken(m_FEDRawDataToken, rawData)) {
@@ -62,9 +62,9 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     return;
   }
   
-  iEvent.put(number , prefix + "Number" + suffix );
-  iEvent.put(my_size, prefix + "Size"   + suffix );
-  iEvent.put(orn    , prefix + "ORN"    + suffix );
-  iEvent.put(bcn    , prefix + "BCN"    + suffix );
+  iEvent.put(move(number ), prefix + "Number" + suffix );
+  iEvent.put(move(my_size), prefix + "Size"   + suffix );
+  iEvent.put(move(orn    ), prefix + "ORN"    + suffix );
+  iEvent.put(move(bcn    ), prefix + "BCN"    + suffix );
  
 }

--- a/plugins/HcalTupleMaker_HcalIsoNoiseFilterParameters.cc
+++ b/plugins/HcalTupleMaker_HcalIsoNoiseFilterParameters.cc
@@ -59,46 +59,46 @@ HcalTupleMaker_HcalIsoNoiseFilterParameters::HcalTupleMaker_HcalIsoNoiseFilterPa
 void HcalTupleMaker_HcalIsoNoiseFilterParameters::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
   
   // iso noise filter params
-  //std::auto_ptr<std::vector<int> >     numisolatednoisechannels  ( new std::vector<int>    ());
-  //std::auto_ptr<std::vector<double> >  isolatednoisesume         ( new std::vector<double> ());
-  //std::auto_ptr<std::vector<double> >  isolatednoisesumet        ( new std::vector<double> ());
+  //std::unique_ptr<std::vector<int> >     numisolatednoisechannels  ( new std::vector<int>    ());
+  //std::unique_ptr<std::vector<double> >  isolatednoisesume         ( new std::vector<double> ());
+  //std::unique_ptr<std::vector<double> >  isolatednoisesumet        ( new std::vector<double> ());
   // rbx clusters
-  std::auto_ptr<std::vector<int> >     crbxid           ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     crbxnhits        ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     crbxistagged     ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     crbxisiso        ( new std::vector<int> ());
-  std::auto_ptr<std::vector<double> >  crbxisolhcale    ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  crbxisolecale    ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  crbxisoltrke     ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  crbxtrkfide      ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  crbxclue         ( new std::vector<double> ());
+  std::unique_ptr<std::vector<int> >     crbxid           ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     crbxnhits        ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     crbxistagged     ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     crbxisiso        ( new std::vector<int> ());
+  std::unique_ptr<std::vector<double> >  crbxisolhcale    ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  crbxisolecale    ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  crbxisoltrke     ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  crbxtrkfide      ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  crbxclue         ( new std::vector<double> ());
   // hpd clusters
-  std::auto_ptr<std::vector<int> >     chpdid           ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     chpdrbxid        ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     chpdistagged     ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     chpdnhits        ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     chpdisiso        ( new std::vector<int> ());
-  std::auto_ptr<std::vector<double> >  chpdisolhcale    ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  chpdisolecale    ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  chpdisoltrke     ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  chpdtrkfide      ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  chpdclue         ( new std::vector<double> ());
+  std::unique_ptr<std::vector<int> >     chpdid           ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     chpdrbxid        ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     chpdistagged     ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     chpdnhits        ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     chpdisiso        ( new std::vector<int> ());
+  std::unique_ptr<std::vector<double> >  chpdisolhcale    ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  chpdisolecale    ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  chpdisoltrke     ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  chpdtrkfide      ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  chpdclue         ( new std::vector<double> ());
   // dihit clusters
-  std::auto_ptr<std::vector<int> >     cdihitistagged   ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     cdihitisiso      ( new std::vector<int> ());
-  std::auto_ptr<std::vector<double> >  cdihitisolhcale  ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cdihitisolecale  ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cdihitisoltrke   ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cdihittrkfide    ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cdihitclue       ( new std::vector<double> ());
+  std::unique_ptr<std::vector<int> >     cdihitistagged   ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     cdihitisiso      ( new std::vector<int> ());
+  std::unique_ptr<std::vector<double> >  cdihitisolhcale  ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cdihitisolecale  ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cdihitisoltrke   ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cdihittrkfide    ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cdihitclue       ( new std::vector<double> ());
   // monohit clusters
-  std::auto_ptr<std::vector<int> >     cmonohitistagged  ( new std::vector<int> ());
-  std::auto_ptr<std::vector<int> >     cmonohitisiso     ( new std::vector<int> ());
-  std::auto_ptr<std::vector<double> >  cmonohitisolhcale ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cmonohitisolecale ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cmonohitisoltrke  ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cmonohittrkfide   ( new std::vector<double> ());
-  std::auto_ptr<std::vector<double> >  cmonohitclue      ( new std::vector<double> ());
+  std::unique_ptr<std::vector<int> >     cmonohitistagged  ( new std::vector<int> ());
+  std::unique_ptr<std::vector<int> >     cmonohitisiso     ( new std::vector<int> ());
+  std::unique_ptr<std::vector<double> >  cmonohitisolhcale ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cmonohitisolecale ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cmonohitisoltrke  ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cmonohittrkfide   ( new std::vector<double> ());
+  std::unique_ptr<std::vector<double> >  cmonohitclue      ( new std::vector<double> ());
 
   // Isolation Filter code
   // Reproduced from: http://cmslxr.fnal.gov/lxr/source/RecoLocalCalo/HcalRecProducers/src/HBHEIsolatedNoiseReflagger.cc?v=CMSSW_7_5_0_pre5
@@ -151,6 +151,12 @@ void HcalTupleMaker_HcalIsoNoiseFilterParameters::produce(edm::Event& iEvent, co
   // get the tracks
   edm::Handle<std::vector<reco::TrackExtrapolation> > trackextraps_h;
   iEvent.getByToken(trackExtrapolatorToken, trackextraps_h);
+
+  // get the emap
+  const HcalFrontEndMap *emap;
+  edm::ESHandle<HcalFrontEndMap> emapHndl;
+  iSetup.get<HcalFrontEndMapRcd>().get(emapHndl);
+  emap = emapHndl.product();
   
   objvalidator_.setHcalChannelQuality(dbHcalChStatus);
   objvalidator_.setEcalChannelStatus(dbEcalChStatus);
@@ -200,7 +206,7 @@ void HcalTupleMaker_HcalIsoNoiseFilterParameters::produce(edm::Event& iEvent, co
   
   // organizer the hits
   PhysicsTowerOrganizer pto(iEvent, iSetup, hbhehits_h, ebhits_h, eehits_h, trackextraps_h, objvalidator_, *(ctcm.product()));
-  HBHEHitMapOrganizer organizer(hbhehits_h, objvalidator_, pto);
+  HBHEHitMapOrganizer organizer(hbhehits_h, objvalidator_, pto, emap);
 
   organizer.getRBXs(rbxs, LooseRBXEne1_<TightRBXEne1_ ? LooseRBXEne1_ : TightRBXEne1_);
   organizer.getHPDs(hpds, LooseHPDEne1_<TightHPDEne1_ ? LooseHPDEne1_ : TightHPDEne1_);
@@ -429,45 +435,45 @@ void HcalTupleMaker_HcalIsoNoiseFilterParameters::produce(edm::Event& iEvent, co
   //isolatednoisesumet       -> push_back ( hSummary->isolatedNoiseSumEt() );
 
   // iso noise filter params
-  //iEvent.put( numisolatednoisechannels , prefix + "NumIsolatedNoiseChannels" + suffix );
-  //iEvent.put( isolatednoisesume        , prefix + "IsolatedNoiseSumE"        + suffix );
-  //iEvent.put( isolatednoisesumet       , prefix + "IsolatedNoiseSumEt"       + suffix );
+  //iEvent.put(move( numisolatednoisechannels), prefix + "NumIsolatedNoiseChannels" + suffix );
+  //iEvent.put(move( isolatednoisesume       ), prefix + "IsolatedNoiseSumE"        + suffix );
+  //iEvent.put(move( isolatednoisesumet      ), prefix + "IsolatedNoiseSumEt"       + suffix );
   //
   // rbx clusters
-  iEvent.put(  crbxid           , prefix + "CRBXId"           + suffix );
-  iEvent.put(  crbxnhits        , prefix + "CRBXNHits"        + suffix );
-  iEvent.put(  crbxistagged     , prefix + "CRBXIsTagged"     + suffix );
-  iEvent.put(  crbxisiso        , prefix + "CRBXIsIso"        + suffix );
-  iEvent.put(  crbxisolhcale    , prefix + "CRBXIsolHcalE"    + suffix );
-  iEvent.put(  crbxisolecale    , prefix + "CRBXIsolEcalE"    + suffix );
-  iEvent.put(  crbxisoltrke     , prefix + "CRBXIsolTrkE"     + suffix );
-  iEvent.put(  crbxtrkfide      , prefix + "CRBXTrkFidE"      + suffix );
-  iEvent.put(  crbxclue         , prefix + "CRBXCluE"         + suffix );
+  iEvent.put(move(  crbxid           ), prefix + "CRBXId"           + suffix );
+  iEvent.put(move(  crbxnhits        ), prefix + "CRBXNHits"        + suffix );
+  iEvent.put(move(  crbxistagged     ), prefix + "CRBXIsTagged"     + suffix );
+  iEvent.put(move(  crbxisiso        ), prefix + "CRBXIsIso"        + suffix );
+  iEvent.put(move(  crbxisolhcale    ), prefix + "CRBXIsolHcalE"    + suffix );
+  iEvent.put(move(  crbxisolecale    ), prefix + "CRBXIsolEcalE"    + suffix );
+  iEvent.put(move(  crbxisoltrke     ), prefix + "CRBXIsolTrkE"     + suffix );
+  iEvent.put(move(  crbxtrkfide      ), prefix + "CRBXTrkFidE"      + suffix );
+  iEvent.put(move(  crbxclue         ), prefix + "CRBXCluE"         + suffix );
   // hpd clusters
-  iEvent.put(  chpdid           , prefix + "CHPDId"           + suffix );
-  iEvent.put(  chpdrbxid        , prefix + "CHPDRBXId"        + suffix );
-  iEvent.put(  chpdistagged     , prefix + "CHPDIsTagged"     + suffix );
-  iEvent.put(  chpdisiso        , prefix + "CHPDIsIso"        + suffix );
-  iEvent.put(  chpdnhits        , prefix + "CHPDNHits"        + suffix );
-  iEvent.put(  chpdisolhcale    , prefix + "CHPDIsolHcalE"    + suffix );
-  iEvent.put(  chpdisolecale    , prefix + "CHPDIsolEcalE"    + suffix );
-  iEvent.put(  chpdisoltrke     , prefix + "CHPDIsolTrkE"     + suffix );
-  iEvent.put(  chpdtrkfide      , prefix + "CHPDTrkFidE"      + suffix );
-  iEvent.put(  chpdclue         , prefix + "CHPDCluE"         + suffix );
+  iEvent.put(move(  chpdid           ), prefix + "CHPDId"           + suffix );
+  iEvent.put(move(  chpdrbxid        ), prefix + "CHPDRBXId"        + suffix );
+  iEvent.put(move(  chpdistagged     ), prefix + "CHPDIsTagged"     + suffix );
+  iEvent.put(move(  chpdisiso        ), prefix + "CHPDIsIso"        + suffix );
+  iEvent.put(move(  chpdnhits        ), prefix + "CHPDNHits"        + suffix );
+  iEvent.put(move(  chpdisolhcale    ), prefix + "CHPDIsolHcalE"    + suffix );
+  iEvent.put(move(  chpdisolecale    ), prefix + "CHPDIsolEcalE"    + suffix );
+  iEvent.put(move(  chpdisoltrke     ), prefix + "CHPDIsolTrkE"     + suffix );
+  iEvent.put(move(  chpdtrkfide      ), prefix + "CHPDTrkFidE"      + suffix );
+  iEvent.put(move(  chpdclue         ), prefix + "CHPDCluE"         + suffix );
   // dihit clusters
-  iEvent.put(  cdihitistagged   , prefix + "CDihitIsTagged"   + suffix );
-  iEvent.put(  cdihitisiso      , prefix + "CDihitIsIso"      + suffix );
-  iEvent.put(  cdihitisolhcale  , prefix + "CDihitIsolHcalE"  + suffix );
-  iEvent.put(  cdihitisolecale  , prefix + "CDihitIsolEcalE"  + suffix );
-  iEvent.put(  cdihitisoltrke   , prefix + "CDihitIsolTrkE"   + suffix );
-  iEvent.put(  cdihittrkfide    , prefix + "CDihitTrkFidE"    + suffix );
-  iEvent.put(  cdihitclue       , prefix + "CDihitCluE"       + suffix );
+  iEvent.put(move(  cdihitistagged   ), prefix + "CDihitIsTagged"   + suffix );
+  iEvent.put(move(  cdihitisiso      ), prefix + "CDihitIsIso"      + suffix );
+  iEvent.put(move(  cdihitisolhcale  ), prefix + "CDihitIsolHcalE"  + suffix );
+  iEvent.put(move(  cdihitisolecale  ), prefix + "CDihitIsolEcalE"  + suffix );
+  iEvent.put(move(  cdihitisoltrke   ), prefix + "CDihitIsolTrkE"   + suffix );
+  iEvent.put(move(  cdihittrkfide    ), prefix + "CDihitTrkFidE"    + suffix );
+  iEvent.put(move(  cdihitclue       ), prefix + "CDihitCluE"       + suffix );
   // monohit clusters
-  iEvent.put(  cmonohitistagged , prefix + "CMonohitIsTagged" + suffix );
-  iEvent.put(  cmonohitisiso    , prefix + "CMonohitIsIso"    + suffix );
-  iEvent.put(  cmonohitisolhcale, prefix + "CMonohitIsolHcalE"+ suffix );
-  iEvent.put(  cmonohitisolecale, prefix + "CMonohitIsolEcalE"+ suffix );
-  iEvent.put(  cmonohitisoltrke , prefix + "CMonohitIsolTrkE" + suffix );
-  iEvent.put(  cmonohittrkfide  , prefix + "CMonohitTrkFidE"  + suffix );
-  iEvent.put(  cmonohitclue     , prefix + "CMonohitCluE"     + suffix );
+  iEvent.put(move(  cmonohitistagged ), prefix + "CMonohitIsTagged" + suffix );
+  iEvent.put(move(  cmonohitisiso    ), prefix + "CMonohitIsIso"    + suffix );
+  iEvent.put(move(  cmonohitisolhcale), prefix + "CMonohitIsolHcalE"+ suffix );
+  iEvent.put(move(  cmonohitisolecale), prefix + "CMonohitIsolEcalE"+ suffix );
+  iEvent.put(move(  cmonohitisoltrke ), prefix + "CMonohitIsolTrkE" + suffix );
+  iEvent.put(move(  cmonohittrkfide  ), prefix + "CMonohitTrkFidE"  + suffix );
+  iEvent.put(move(  cmonohitclue     ), prefix + "CMonohitCluE"     + suffix );
 }

--- a/plugins/HcalTupleMaker_HcalLaserDigis.cc
+++ b/plugins/HcalTupleMaker_HcalLaserDigis.cc
@@ -20,10 +20,10 @@ HcalTupleMaker_HcalLaserDigis::HcalTupleMaker_HcalLaserDigis(const edm::Paramete
 
 void HcalTupleMaker_HcalLaserDigis::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
   
-  std::auto_ptr<std::vector<int   > > qadc          ( new std::vector<int>    ());
-  std::auto_ptr<std::vector<int   > > tdcHitChannel ( new std::vector<int>    ());
-  std::auto_ptr<std::vector<int   > > tdcHitRaw     ( new std::vector<int>    ());
-  std::auto_ptr<std::vector<double> > tdcHitNS      ( new std::vector<double> ());
+  std::unique_ptr<std::vector<int   > > qadc          ( new std::vector<int>    ());
+  std::unique_ptr<std::vector<int   > > tdcHitChannel ( new std::vector<int>    ());
+  std::unique_ptr<std::vector<int   > > tdcHitRaw     ( new std::vector<int>    ());
+  std::unique_ptr<std::vector<double> > tdcHitNS      ( new std::vector<double> ());
 
   edm::Handle <HcalLaserDigi> digi;
   iEvent.getByToken(m_hcalLaserDigiToken, digi);
@@ -38,16 +38,16 @@ void HcalTupleMaker_HcalLaserDigis::produce(edm::Event& iEvent, const edm::Event
     tdcHitNS      -> push_back ( digi -> hitNS      ( iTDC ) );
   }
 
-  std::auto_ptr<int> attenuator1 ( new int(digi -> attenuator1()) );
-  std::auto_ptr<int> attenuator2 ( new int(digi -> attenuator2()) );
-  std::auto_ptr<int> selector    ( new int(digi -> selector   ()) );
+  std::unique_ptr<int> attenuator1 ( new int(digi -> attenuator1()) );
+  std::unique_ptr<int> attenuator2 ( new int(digi -> attenuator2()) );
+  std::unique_ptr<int> selector    ( new int(digi -> selector   ()) );
 
-  iEvent.put( qadc          , prefix + "QADC"          + suffix ); 
-  iEvent.put( tdcHitChannel , prefix + "TDCHitChannel" + suffix ); 
-  iEvent.put( tdcHitRaw     , prefix + "TDCHitRaw"     + suffix );  
-  iEvent.put( tdcHitNS      , prefix + "TDCHitNS"      + suffix );  
-  iEvent.put( attenuator1   , prefix + "Attenuator1"   + suffix );
-  iEvent.put( attenuator2   , prefix + "Attenuator2"   + suffix );
-  iEvent.put( selector      , prefix + "Selector"      + suffix );
+  iEvent.put(move( qadc         ) , prefix + "QADC"          + suffix );
+  iEvent.put(move( tdcHitChannel) , prefix + "TDCHitChannel" + suffix );
+  iEvent.put(move( tdcHitRaw    ) , prefix + "TDCHitRaw"     + suffix );
+  iEvent.put(move( tdcHitNS     ) , prefix + "TDCHitNS"      + suffix );
+  iEvent.put(move( attenuator1  ) , prefix + "Attenuator1"   + suffix );
+  iEvent.put(move( attenuator2  ) , prefix + "Attenuator2"   + suffix );
+  iEvent.put(move( selector     ) , prefix + "Selector"      + suffix );
   
 }

--- a/plugins/HcalTupleMaker_HcalNoiseFilters.cc
+++ b/plugins/HcalTupleMaker_HcalNoiseFilters.cc
@@ -83,44 +83,44 @@ HcalTupleMaker_HcalNoiseFilters::HcalTupleMaker_HcalNoiseFilters(const edm::Para
 
 void HcalTupleMaker_HcalNoiseFilters::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
   
-  std::auto_ptr<std::vector<int> >                  officialdecision           ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  officialdecisionrun1       ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  officialdecisionrun2l      ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  officialdecisionrun2t      ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  isonoisefilterdecision     ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  hpdhits                    ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  hpdnootherhits             ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  maxzeros                   ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<double> >               mine2e10                   ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<double> >               maxe2e10                   ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<int> >                  hasbadrbxr45               ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  hasbadrbxrechitr45loose    ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  hasbadrbxrechitr45tight    ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<int> >                  numisolatednoisechannels   ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<double> >               isolatednoisesume          ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<double> >               isolatednoisesumet         ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<int> >                  numnegativenoisechannels   ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<double> >               negativenoisesume          ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<double> >               negativenoisesumet         ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<int> >                  numspikenoisechannels      ( new std::vector<int>                  ());
-  std::auto_ptr<std::vector<double> >               spikenoisesume             ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<double> >               spikenoisesumet            ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<int> >                  officialdecision           ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  officialdecisionrun1       ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  officialdecisionrun2l      ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  officialdecisionrun2t      ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  isonoisefilterdecision     ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  hpdhits                    ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  hpdnootherhits             ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  maxzeros                   ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<double> >               mine2e10                   ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<double> >               maxe2e10                   ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<int> >                  hasbadrbxr45               ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  hasbadrbxrechitr45loose    ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  hasbadrbxrechitr45tight    ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<int> >                  numisolatednoisechannels   ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<double> >               isolatednoisesume          ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<double> >               isolatednoisesumet         ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<int> >                  numnegativenoisechannels   ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<double> >               negativenoisesume          ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<double> >               negativenoisesumet         ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<int> >                  numspikenoisechannels      ( new std::vector<int>                  ());
+  std::unique_ptr<std::vector<double> >               spikenoisesume             ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<double> >               spikenoisesumet            ( new std::vector<double>               ());
   //
-  std::auto_ptr<std::vector<std::vector<double> > > rbxcharge                  ( new std::vector<std::vector<double> > ());
-  std::auto_ptr<std::vector<std::vector<double> > > rbxcharge15                ( new std::vector<std::vector<double> > ());
-  std::auto_ptr<std::vector<double> >               rbxenergy                  ( new std::vector<double>               ());
-  std::auto_ptr<std::vector<double> >               rbxenergy15                ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<std::vector<double> > > rbxcharge                  ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<std::vector<double> > > rbxcharge15                ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<double> >               rbxenergy                  ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<double> >               rbxenergy15                ( new std::vector<double>               ());
   //
-  std::auto_ptr<std::vector<double> >               hbherechitenergyraw        ( new std::vector<double>               ());
+  std::unique_ptr<std::vector<double> >               hbherechitenergyraw        ( new std::vector<double>               ());
   //
-  std::auto_ptr<std::vector<std::vector<int> > >    hbherechitauxcapid         ( new std::vector<std::vector<int> >    ());   
-  std::auto_ptr<std::vector<std::vector<int> > >    hbherechitauxadc           ( new std::vector<std::vector<int> >    ());   
-  std::auto_ptr<std::vector<std::vector<double> > > hbherechitauxallfc         ( new std::vector<std::vector<double> > ());   
-  std::auto_ptr<std::vector<std::vector<double> > > hbherechitauxpedfc         ( new std::vector<std::vector<double> > ());
-  std::auto_ptr<std::vector<std::vector<double> > > hbherechitauxgain          ( new std::vector<std::vector<double> > ());
-  std::auto_ptr<std::vector<std::vector<double> > > hbherechitauxrcgain        ( new std::vector<std::vector<double> > ());
-  std::auto_ptr<std::vector<std::vector<double> > > hbherechitauxfc            ( new std::vector<std::vector<double> > ());
-  std::auto_ptr<std::vector<std::vector<double> > > hbherechitauxenergy        ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<std::vector<int> > >    hbherechitauxcapid         ( new std::vector<std::vector<int> >    ());
+  std::unique_ptr<std::vector<std::vector<int> > >    hbherechitauxadc           ( new std::vector<std::vector<int> >    ());
+  std::unique_ptr<std::vector<std::vector<double> > > hbherechitauxallfc         ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<std::vector<double> > > hbherechitauxpedfc         ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<std::vector<double> > > hbherechitauxgain          ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<std::vector<double> > > hbherechitauxrcgain        ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<std::vector<double> > > hbherechitauxfc            ( new std::vector<std::vector<double> > ());
+  std::unique_ptr<std::vector<std::vector<double> > > hbherechitauxenergy        ( new std::vector<std::vector<double> > ());
 
 
   edm::Handle<bool> hNoiseResult;
@@ -420,42 +420,42 @@ void HcalTupleMaker_HcalNoiseFilters::produce(edm::Event& iEvent, const edm::Eve
   }
   */
 
-  iEvent.put( officialdecision         , prefix + "OfficialDecision"         + suffix );
-  iEvent.put( officialdecisionrun1     , prefix + "OfficialDecisionRun1"     + suffix );
-  iEvent.put( officialdecisionrun2l    , prefix + "OfficialDecisionRun2L"    + suffix );
-  iEvent.put( officialdecisionrun2t    , prefix + "OfficialDecisionRun2T"    + suffix );
-  iEvent.put( isonoisefilterdecision   , prefix + "IsoNoiseFilterDecision"   + suffix );
-  iEvent.put( hpdhits                  , prefix + "HPDHits"                  + suffix );
-  iEvent.put( hpdnootherhits           , prefix + "HPDNoOtherHits"           + suffix );
-  iEvent.put( maxzeros                 , prefix + "MaxZeros"                 + suffix );
-  iEvent.put( mine2e10                 , prefix + "MinE2E10"                 + suffix );
-  iEvent.put( maxe2e10                 , prefix + "MaxE2E10"                 + suffix );
-  iEvent.put( hasbadrbxr45             , prefix + "HasBadRBXR45"             + suffix );
-  iEvent.put( hasbadrbxrechitr45loose  , prefix + "HasBadRBXRechitR45Loose"  + suffix );
-  iEvent.put( hasbadrbxrechitr45tight  , prefix + "HasBadRBXRechitR45Tight"  + suffix );
-  iEvent.put( numisolatednoisechannels , prefix + "NumIsolatedNoiseChannels" + suffix );
-  iEvent.put( isolatednoisesume        , prefix + "IsolatedNoiseSumE"        + suffix );
-  iEvent.put( isolatednoisesumet       , prefix + "IsolatedNoiseSumEt"       + suffix );
-  iEvent.put( numnegativenoisechannels , prefix + "NumNegativeNoiseChannels" + suffix );
-  iEvent.put( negativenoisesume        , prefix + "NegativeNoiseSumE"        + suffix );
-  iEvent.put( negativenoisesumet       , prefix + "NegativeNoiseSumEt"       + suffix );
-  iEvent.put( numspikenoisechannels    , prefix + "NumSpikeNoiseChannels"    + suffix );
-  iEvent.put( spikenoisesume           , prefix + "SpikeNoiseSumE"           + suffix );
-  iEvent.put( spikenoisesumet          , prefix + "SpikeNoiseSumEt"          + suffix );
+  iEvent.put(move( officialdecision        ) , prefix + "OfficialDecision"         + suffix );
+  iEvent.put(move( officialdecisionrun1    ) , prefix + "OfficialDecisionRun1"     + suffix );
+  iEvent.put(move( officialdecisionrun2l   ) , prefix + "OfficialDecisionRun2L"    + suffix );
+  iEvent.put(move( officialdecisionrun2t   ) , prefix + "OfficialDecisionRun2T"    + suffix );
+  iEvent.put(move( isonoisefilterdecision  ) , prefix + "IsoNoiseFilterDecision"   + suffix );
+  iEvent.put(move( hpdhits                 ) , prefix + "HPDHits"                  + suffix );
+  iEvent.put(move( hpdnootherhits          ) , prefix + "HPDNoOtherHits"           + suffix );
+  iEvent.put(move( maxzeros                ) , prefix + "MaxZeros"                 + suffix );
+  iEvent.put(move( mine2e10                ) , prefix + "MinE2E10"                 + suffix );
+  iEvent.put(move( maxe2e10                ) , prefix + "MaxE2E10"                 + suffix );
+  iEvent.put(move( hasbadrbxr45            ) , prefix + "HasBadRBXR45"             + suffix );
+  iEvent.put(move( hasbadrbxrechitr45loose ) , prefix + "HasBadRBXRechitR45Loose"  + suffix );
+  iEvent.put(move( hasbadrbxrechitr45tight ) , prefix + "HasBadRBXRechitR45Tight"  + suffix );
+  iEvent.put(move( numisolatednoisechannels) , prefix + "NumIsolatedNoiseChannels" + suffix );
+  iEvent.put(move( isolatednoisesume       ) , prefix + "IsolatedNoiseSumE"        + suffix );
+  iEvent.put(move( isolatednoisesumet      ) , prefix + "IsolatedNoiseSumEt"       + suffix );
+  iEvent.put(move( numnegativenoisechannels) , prefix + "NumNegativeNoiseChannels" + suffix );
+  iEvent.put(move( negativenoisesume       ) , prefix + "NegativeNoiseSumE"        + suffix );
+  iEvent.put(move( negativenoisesumet      ) , prefix + "NegativeNoiseSumEt"       + suffix );
+  iEvent.put(move( numspikenoisechannels   ) , prefix + "NumSpikeNoiseChannels"    + suffix );
+  iEvent.put(move( spikenoisesume          ) , prefix + "SpikeNoiseSumE"           + suffix );
+  iEvent.put(move( spikenoisesumet         ) , prefix + "SpikeNoiseSumEt"          + suffix );
   //
-  iEvent.put( rbxcharge                , prefix + "RBXCharge"                + suffix );
-  iEvent.put( rbxcharge15              , prefix + "RBXCharge15"              + suffix );
-  iEvent.put( rbxenergy                , prefix + "RBXEnergy"                + suffix );
-  iEvent.put( rbxenergy15              , prefix + "RBXEnergy15"              + suffix );
+  iEvent.put(move( rbxcharge               ) , prefix + "RBXCharge"                + suffix );
+  iEvent.put(move( rbxcharge15             ) , prefix + "RBXCharge15"              + suffix );
+  iEvent.put(move( rbxenergy               ) , prefix + "RBXEnergy"                + suffix );
+  iEvent.put(move( rbxenergy15             ) , prefix + "RBXEnergy15"              + suffix );
   //
-  iEvent.put( hbherechitenergyraw      , prefix + "HBHERecHitEnergyRaw"      + suffix );
+  iEvent.put(move( hbherechitenergyraw     ) , prefix + "HBHERecHitEnergyRaw"      + suffix );
   //
-  iEvent.put( hbherechitauxcapid       , prefix + "HBHERecHitAuxCapID"       + suffix ); 
-  iEvent.put( hbherechitauxadc         , prefix + "HBHERecHitAuxADC"         + suffix ); 
-  iEvent.put( hbherechitauxallfc       , prefix + "HBHERecHitAuxAllfC"       + suffix ); 
-  iEvent.put( hbherechitauxpedfc       , prefix + "HBHERecHitAuxPedFC"       + suffix );
-  iEvent.put( hbherechitauxgain        , prefix + "HBHERecHitAuxGain"        + suffix );
-  iEvent.put( hbherechitauxrcgain      , prefix + "HBHERecHitAuxRCGain"      + suffix );
-  iEvent.put( hbherechitauxfc          , prefix + "HBHERecHitAuxFC"          + suffix );  
-  iEvent.put( hbherechitauxenergy      , prefix + "HBHERecHitAuxEnergy"      + suffix );
+  iEvent.put(move( hbherechitauxcapid      ) , prefix + "HBHERecHitAuxCapID"       + suffix );
+  iEvent.put(move( hbherechitauxadc        ) , prefix + "HBHERecHitAuxADC"         + suffix );
+  iEvent.put(move( hbherechitauxallfc      ) , prefix + "HBHERecHitAuxAllfC"       + suffix );
+  iEvent.put(move( hbherechitauxpedfc      ) , prefix + "HBHERecHitAuxPedFC"       + suffix );
+  iEvent.put(move( hbherechitauxgain       ) , prefix + "HBHERecHitAuxGain"        + suffix );
+  iEvent.put(move( hbherechitauxrcgain     ) , prefix + "HBHERecHitAuxRCGain"      + suffix );
+  iEvent.put(move( hbherechitauxfc         ) , prefix + "HBHERecHitAuxFC"          + suffix );
+  iEvent.put(move( hbherechitauxenergy     ) , prefix + "HBHERecHitAuxEnergy"      + suffix );
 }

--- a/plugins/HcalTupleMaker_HcalTriggerPrimitives.cc
+++ b/plugins/HcalTupleMaker_HcalTriggerPrimitives.cc
@@ -32,16 +32,16 @@ HcalTupleMaker_HcalTriggerPrimitives::HcalTupleMaker_HcalTriggerPrimitives(const
 
 void HcalTupleMaker_HcalTriggerPrimitives::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
 
-  std::auto_ptr<std::vector<int   > >            ieta              ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<int   > >            iphi              ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<int   > >            SOI_compressedEt  ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<int   > >            SOI_fineGrain     ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<int   > >            size              ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<int   > >            presamples        ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<std::vector<int> > > compressedEt      ( new std::vector<std::vector<int> >());
-  std::auto_ptr<std::vector<std::vector<int> > > fineGrain         ( new std::vector<std::vector<int> >());
-  std::auto_ptr<std::vector<std::vector<int> > > hbheDigiIndex     ( new std::vector<std::vector<int> >());
-  std::auto_ptr<std::vector<std::vector<int> > > hfDigiIndex       ( new std::vector<std::vector<int> >());
+  std::unique_ptr<std::vector<int   > >            ieta              ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<int   > >            iphi              ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<int   > >            SOI_compressedEt  ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<int   > >            SOI_fineGrain     ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<int   > >            size              ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<int   > >            presamples        ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<std::vector<int> > > compressedEt      ( new std::vector<std::vector<int> >());
+  std::unique_ptr<std::vector<std::vector<int> > > fineGrain         ( new std::vector<std::vector<int> >());
+  std::unique_ptr<std::vector<std::vector<int> > > hbheDigiIndex     ( new std::vector<std::vector<int> >());
+  std::unique_ptr<std::vector<std::vector<int> > > hfDigiIndex       ( new std::vector<std::vector<int> >());
 
   edm::ESHandle<HcalTrigTowerGeometry> geometry;
   iSetup.get<CaloGeometryRecord>().get(geometry);
@@ -118,16 +118,16 @@ void HcalTupleMaker_HcalTriggerPrimitives::produce(edm::Event& iEvent, const edm
     }
   }
   
-  iEvent.put( ieta             , prefix + "IEta"            + suffix );
-  iEvent.put( iphi             , prefix + "IPhi"            + suffix );
-  iEvent.put( SOI_compressedEt , prefix + "CompressedEtSOI" + suffix );
-  iEvent.put( SOI_fineGrain    , prefix + "FineGrainSOI"    + suffix );
-  iEvent.put( presamples       , prefix + "Size"            + suffix );
-  iEvent.put( size             , prefix + "Presamples"      + suffix );
+  iEvent.put(move( ieta            )  , prefix + "IEta"            + suffix );
+  iEvent.put(move( iphi            ) , prefix + "IPhi"            + suffix );
+  iEvent.put(move( SOI_compressedEt) , prefix + "CompressedEtSOI" + suffix );
+  iEvent.put(move( SOI_fineGrain   ) , prefix + "FineGrainSOI"    + suffix );
+  iEvent.put(move( presamples      ) , prefix + "Size"            + suffix );
+  iEvent.put(move( size            ) , prefix + "Presamples"      + suffix );
   
-  iEvent.put( compressedEt     , prefix + "CompressedEt"    + suffix );
-  iEvent.put( fineGrain        , prefix + "FineGrain"       + suffix );
-  iEvent.put( hbheDigiIndex    , prefix + "HBHEDigiIndex"   + suffix );
-  iEvent.put( hfDigiIndex      , prefix + "HFDigiIndex"     + suffix );
+  iEvent.put(move( compressedEt    ) , prefix + "CompressedEt"    + suffix );
+  iEvent.put(move( fineGrain       ) , prefix + "FineGrain"       + suffix );
+  iEvent.put(move( hbheDigiIndex   ) , prefix + "HBHEDigiIndex"   + suffix );
+  iEvent.put(move( hfDigiIndex     ) , prefix + "HFDigiIndex"     + suffix );
   
 }

--- a/plugins/HcalTupleMaker_HcalUnpackerReport.cc
+++ b/plugins/HcalTupleMaker_HcalUnpackerReport.cc
@@ -32,22 +32,22 @@ HcalTupleMaker_HcalUnpackerReport::HcalTupleMaker_HcalUnpackerReport(const edm::
 void HcalTupleMaker_HcalUnpackerReport::
 produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-  std::auto_ptr<unsigned int>      errorFree          ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      anyValid           ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      spigotFormatErrors ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      badDigis           ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      totalDigis         ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      totalTPDigis       ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      totalHOTPDigis     ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      emptySpigots       ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      OFWSpigots         ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      BSYSpigots         ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      unsuppressed       ( new unsigned int()      );
-  std::auto_ptr<unsigned int>      calibrationPresent ( new unsigned int()      );
-  std::auto_ptr<std::vector<int> > badDigiIEta        ( new std::vector<int> () );
-  std::auto_ptr<std::vector<int> > badDigiIPhi        ( new std::vector<int> () );
-  std::auto_ptr<std::vector<int> > badDigiDepth       ( new std::vector<int> () );
-  std::auto_ptr<std::vector<int> > badDigiSubdet      ( new std::vector<int> () );
+  std::unique_ptr<unsigned int>      errorFree          ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      anyValid           ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      spigotFormatErrors ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      badDigis           ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      totalDigis         ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      totalTPDigis       ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      totalHOTPDigis     ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      emptySpigots       ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      OFWSpigots         ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      BSYSpigots         ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      unsuppressed       ( new unsigned int()      );
+  std::unique_ptr<unsigned int>      calibrationPresent ( new unsigned int()      );
+  std::unique_ptr<std::vector<int> > badDigiIEta        ( new std::vector<int> () );
+  std::unique_ptr<std::vector<int> > badDigiIPhi        ( new std::vector<int> () );
+  std::unique_ptr<std::vector<int> > badDigiDepth       ( new std::vector<int> () );
+  std::unique_ptr<std::vector<int> > badDigiSubdet      ( new std::vector<int> () );
   
   edm::Handle<HcalUnpackerReport> report;
 
@@ -88,21 +88,21 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     return;
   }
   
-  iEvent.put ( errorFree          , prefix + "ErrorFree"           + suffix );
-  iEvent.put ( anyValid           , prefix + "AnyValid"            + suffix );
-  iEvent.put ( spigotFormatErrors , prefix + "SpigotFormatErrors"  + suffix );
-  iEvent.put ( badDigis           , prefix + "BadQualityDigis"     + suffix );
-  iEvent.put ( totalDigis         , prefix + "TotalDigis"          + suffix );
-  iEvent.put ( totalTPDigis       , prefix + "TotalTPDigis"        + suffix );
-  iEvent.put ( totalHOTPDigis     , prefix + "TotalHOTPDigis"      + suffix );
-  iEvent.put ( emptySpigots       , prefix + "EmptySpigots"        + suffix );
-  iEvent.put ( OFWSpigots         , prefix + "OFWSpigots"          + suffix );
-  iEvent.put ( BSYSpigots         , prefix + "BSYSpigots"          + suffix );
-  iEvent.put ( unsuppressed       , prefix + "NZS"                 + suffix );
-  iEvent.put ( calibrationPresent , prefix + "HasCalib"            + suffix );
-  iEvent.put ( badDigiIEta        , prefix + "BadDigiIEta"         + suffix );
-  iEvent.put ( badDigiIPhi        , prefix + "BadDigiIPhi"         + suffix );
-  iEvent.put ( badDigiDepth       , prefix + "BadDigiDepth"        + suffix );
-  iEvent.put ( badDigiSubdet      , prefix + "BadDigiSubdet"       + suffix );
+  iEvent.put ( move( errorFree          ), prefix + "ErrorFree"           + suffix );
+  iEvent.put ( move( anyValid           ), prefix + "AnyValid"            + suffix );
+  iEvent.put ( move( spigotFormatErrors ), prefix + "SpigotFormatErrors"  + suffix );
+  iEvent.put ( move( badDigis           ), prefix + "BadQualityDigis"     + suffix );
+  iEvent.put ( move( totalDigis         ), prefix + "TotalDigis"          + suffix );
+  iEvent.put ( move( totalTPDigis       ), prefix + "TotalTPDigis"        + suffix );
+  iEvent.put ( move( totalHOTPDigis     ), prefix + "TotalHOTPDigis"      + suffix );
+  iEvent.put ( move( emptySpigots       ), prefix + "EmptySpigots"        + suffix );
+  iEvent.put ( move( OFWSpigots         ), prefix + "OFWSpigots"          + suffix );
+  iEvent.put ( move( BSYSpigots         ), prefix + "BSYSpigots"          + suffix );
+  iEvent.put ( move( unsuppressed       ), prefix + "NZS"                 + suffix );
+  iEvent.put ( move( calibrationPresent ), prefix + "HasCalib"            + suffix );
+  iEvent.put ( move( badDigiIEta        ), prefix + "BadDigiIEta"         + suffix );
+  iEvent.put ( move( badDigiIPhi        ), prefix + "BadDigiIPhi"         + suffix );
+  iEvent.put ( move( badDigiDepth       ), prefix + "BadDigiDepth"        + suffix );
+  iEvent.put ( move( badDigiSubdet      ), prefix + "BadDigiSubdet"       + suffix );
 
 }

--- a/plugins/HcalTupleMaker_L1GCTJets.cc
+++ b/plugins/HcalTupleMaker_L1GCTJets.cc
@@ -24,8 +24,8 @@ HcalTupleMaker_L1GCTJets::HcalTupleMaker_L1GCTJets(const edm::ParameterSet& iCon
 
 void HcalTupleMaker_L1GCTJets::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
 
-  std::auto_ptr<std::vector<int   > >            bx      ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<std::vector<int> > > tpIndex ( new std::vector<std::vector<int> >());
+  std::unique_ptr<std::vector<int   > >            bx      ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<std::vector<int> > > tpIndex ( new std::vector<std::vector<int> >());
   
   
   edm::ESHandle< L1CaloEtScale > jetScale ;
@@ -72,7 +72,7 @@ void HcalTupleMaker_L1GCTJets::produce(edm::Event& iEvent, const edm::EventSetup
     }
   }
 
-  iEvent.put(bx     , prefix + "BX"            + suffix );
-  iEvent.put(tpIndex, prefix + "TrigPrimIndex" + suffix );
+  iEvent.put(move(bx)     , prefix + "BX"            + suffix );
+  iEvent.put(move(tpIndex), prefix + "TrigPrimIndex" + suffix );
   
 }

--- a/plugins/HcalTupleMaker_L1Jets.cc
+++ b/plugins/HcalTupleMaker_L1Jets.cc
@@ -24,12 +24,12 @@ HcalTupleMaker_L1Jets::HcalTupleMaker_L1Jets(const edm::ParameterSet& iConfig):
 
 void HcalTupleMaker_L1Jets::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
   
-  std::auto_ptr<std::vector<double> >            pt      ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            eta     ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            phi     ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<int   > >            type    ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<int   > >            bx      ( new std::vector<int>              ());
-  std::auto_ptr<std::vector<std::vector<int> > > tpIndex ( new std::vector<std::vector<int> >());
+  std::unique_ptr<std::vector<double> >            pt      ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            eta     ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            phi     ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<int   > >            type    ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<int   > >            bx      ( new std::vector<int>              ());
+  std::unique_ptr<std::vector<std::vector<int> > > tpIndex ( new std::vector<std::vector<int> >());
 
   int nL1JetCollections = inputTags.size();
   std::vector<edm::Handle<l1extra::L1JetParticleCollection> > l1Jets ( nL1JetCollections );
@@ -73,11 +73,11 @@ void HcalTupleMaker_L1Jets::produce(edm::Event& iEvent, const edm::EventSetup& i
     }
   }
 
-  iEvent.put(pt     , prefix + "Pt"            + suffix );
-  iEvent.put(eta    , prefix + "Eta"           + suffix );
-  iEvent.put(phi    , prefix + "Phi"           + suffix );
-  iEvent.put(bx     , prefix + "BX"            + suffix );
-  iEvent.put(type   , prefix + "Type"           + suffix );
-  iEvent.put(tpIndex, prefix + "TrigPrimIndex" + suffix );
+  iEvent.put(move(pt)     , prefix + "Pt"            + suffix );
+  iEvent.put(move(eta)    , prefix + "Eta"           + suffix );
+  iEvent.put(move(phi)    , prefix + "Phi"           + suffix );
+  iEvent.put(move(bx)     , prefix + "BX"            + suffix );
+  iEvent.put(move(type)   , prefix + "Type"           + suffix );
+  iEvent.put(move(tpIndex), prefix + "TrigPrimIndex" + suffix );
   
 }

--- a/plugins/HcalTupleMaker_MuonTrack.cc
+++ b/plugins/HcalTupleMaker_MuonTrack.cc
@@ -64,24 +64,24 @@ HcalTupleMaker_MuonTrack::HcalTupleMaker_MuonTrack(const edm::ParameterSet& iCon
 }
 
 void HcalTupleMaker_MuonTrack::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
-  std::auto_ptr<std::vector<double> >            muoneta       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            muonpt        ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            muonphi       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            muoncalenergyhads9     ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            muoncalenergyhad       ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            muoncalenergyems25     ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<double> >            muoncalenergyem        ( new std::vector<double>           ());
-  std::auto_ptr<std::vector<int> >               muonnumberofchambers         ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muonnumberofmatchedstations  ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muonnumberofmatchedrpclayers ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<double> >            muoneta       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            muonpt        ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            muonphi       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            muoncalenergyhads9     ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            muoncalenergyhad       ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            muoncalenergyems25     ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<double> >            muoncalenergyem        ( new std::vector<double>           ());
+  std::unique_ptr<std::vector<int> >               muonnumberofchambers         ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muonnumberofmatchedstations  ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muonnumberofmatchedrpclayers ( new std::vector<int>               ());
   //
-  std::auto_ptr<std::vector<int> >               muoncsc2drechitssize         ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muonrpcrechitssize           ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muondt1drechitssize          ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muondt1dcosmicrechitssize    ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muoncscsegmentssize          ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muondtrecsegmentssize        ( new std::vector<int>               ());
-  std::auto_ptr<std::vector<int> >               muondtreccosmicsegmentssize  ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muoncsc2drechitssize         ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muonrpcrechitssize           ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muondt1drechitssize          ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muondt1dcosmicrechitssize    ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muoncscsegmentssize          ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muondtrecsegmentssize        ( new std::vector<int>               ());
+  std::unique_ptr<std::vector<int> >               muondtreccosmicsegmentssize  ( new std::vector<int>               ());
 
   //Get Muon DT, CSC, RPC rechits, segments:
   edm::Handle<CSCSegmentCollection> hCSCSegments;
@@ -164,23 +164,23 @@ void HcalTupleMaker_MuonTrack::produce(edm::Event& iEvent, const edm::EventSetup
     //std::cout<<"       hMuons.isolationR05.emEt: "<<(*mu).isolationR05().emEt<<std::endl;
   }
   
-  iEvent.put(muoneta    , prefix + "MuonEta"                        + suffix );
-  iEvent.put(muonpt     , prefix + "MuonPt"                         + suffix );
-  iEvent.put(muonphi    , prefix + "MuonPhi"                        + suffix );
+  iEvent.put(move(muoneta)    , prefix + "MuonEta"                        + suffix );
+  iEvent.put(move(muonpt)     , prefix + "MuonPt"                         + suffix );
+  iEvent.put(move(muonphi)    , prefix + "MuonPhi"                        + suffix );
   //
-  iEvent.put(muoncalenergyhads9 ,           prefix + "MuonCalEnergyHadS9"             + suffix );
-  iEvent.put(muoncalenergyhad   ,           prefix + "MuonCalEnergyHad"               + suffix );
-  iEvent.put(muoncalenergyems25 ,           prefix + "MuonCalEnergyEmS25"             + suffix );
-  iEvent.put(muoncalenergyem    ,           prefix + "MuonCalEnergyEm"                + suffix );
-  iEvent.put(muonnumberofchambers         , prefix + "MuonNumberOfChambers"           + suffix );
-  iEvent.put(muonnumberofmatchedstations  , prefix + "MuonNumberOfMatchedStations"    + suffix );
-  iEvent.put(muonnumberofmatchedrpclayers , prefix + "MuonNumberOfMatchedRPCLayers"   + suffix );
+  iEvent.put(move(muoncalenergyhads9) ,           prefix + "MuonCalEnergyHadS9"             + suffix );
+  iEvent.put(move(muoncalenergyhad)   ,           prefix + "MuonCalEnergyHad"               + suffix );
+  iEvent.put(move(muoncalenergyems25) ,           prefix + "MuonCalEnergyEmS25"             + suffix );
+  iEvent.put(move(muoncalenergyem)    ,           prefix + "MuonCalEnergyEm"                + suffix );
+  iEvent.put(move(muonnumberofchambers)         , prefix + "MuonNumberOfChambers"           + suffix );
+  iEvent.put(move(muonnumberofmatchedstations)  , prefix + "MuonNumberOfMatchedStations"    + suffix );
+  iEvent.put(move(muonnumberofmatchedrpclayers) , prefix + "MuonNumberOfMatchedRPCLayers"   + suffix );
   //
-  iEvent.put(muoncsc2drechitssize,          prefix + "MuonCSC2DRecHitsSize"           + suffix );
-  iEvent.put(muonrpcrechitssize  ,          prefix + "MuonRPCRecHitsSize"             + suffix );
-  iEvent.put(muondt1drechitssize ,          prefix + "MuonDT1DRecHitsSize"            + suffix );
-  iEvent.put(muondt1dcosmicrechitssize  ,   prefix + "MuonDT1DCosmicRecHitsSize"      + suffix );
-  iEvent.put(muoncscsegmentssize        ,   prefix + "MuonCSCSegmentsSize"            + suffix );
-  iEvent.put(muondtrecsegmentssize      ,   prefix + "MuonDTRecSegmentsSize"          + suffix );
-  iEvent.put(muondtreccosmicsegmentssize,   prefix + "MuonDTRecCosmicSegmentsSize"    + suffix );
+  iEvent.put(move(muoncsc2drechitssize),          prefix + "MuonCSC2DRecHitsSize"           + suffix );
+  iEvent.put(move(muonrpcrechitssize)  ,          prefix + "MuonRPCRecHitsSize"             + suffix );
+  iEvent.put(move(muondt1drechitssize) ,          prefix + "MuonDT1DRecHitsSize"            + suffix );
+  iEvent.put(move(muondt1dcosmicrechitssize)  ,   prefix + "MuonDT1DCosmicRecHitsSize"      + suffix );
+  iEvent.put(move(muoncscsegmentssize)        ,   prefix + "MuonCSCSegmentsSize"            + suffix );
+  iEvent.put(move(muondtrecsegmentssize)      ,   prefix + "MuonDTRecSegmentsSize"          + suffix );
+  iEvent.put(move(muondtreccosmicsegmentssize),   prefix + "MuonDTRecCosmicSegmentsSize"    + suffix );
 }

--- a/plugins/HcalTupleMaker_QIE10Digis.cc
+++ b/plugins/HcalTupleMaker_QIE10Digis.cc
@@ -91,20 +91,20 @@ HcalTupleMaker_QIE10Digis::HcalTupleMaker_QIE10Digis(const edm::ParameterSet& iC
 
 void HcalTupleMaker_QIE10Digis::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     
-  std::auto_ptr<std::vector<int> >                    ieta   ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    iphi   ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    subdet ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    depth  ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    rawId  ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    linkEr ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    flags  ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    soi    ( new std::vector<std::vector<int  > >   ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    ok     ( new std::vector<std::vector<int  > >   ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    adc    ( new std::vector<std::vector<int  > >    ());
-  std::auto_ptr<std::vector<std::vector<double  > > > fc     ( new std::vector<std::vector<double  > > ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    le_tdc ( new std::vector<std::vector<int  > >    ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    te_tdc ( new std::vector<std::vector<int  > >    ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    capid  ( new std::vector<std::vector<int  > >    ());
+  std::unique_ptr<std::vector<int> >                    ieta   ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    iphi   ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    subdet ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    depth  ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    rawId  ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    linkEr ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    flags  ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    soi    ( new std::vector<std::vector<int  > >   ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    ok     ( new std::vector<std::vector<int  > >   ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    adc    ( new std::vector<std::vector<int  > >    ());
+  std::unique_ptr<std::vector<std::vector<double  > > > fc     ( new std::vector<std::vector<double  > > ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    le_tdc ( new std::vector<std::vector<int  > >    ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    te_tdc ( new std::vector<std::vector<int  > >    ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    capid  ( new std::vector<std::vector<int  > >    ());
     
   //
   edm::Handle<QIE10DigiCollection>  qie10Digis;
@@ -166,19 +166,19 @@ void HcalTupleMaker_QIE10Digis::produce(edm::Event& iEvent, const edm::EventSetu
   }
 
   //  
-  iEvent.put( ieta          , "QIE10DigiIEta"      ); 
-  iEvent.put( iphi          , "QIE10DigiIPhi"      ); 
-  iEvent.put( subdet        , "QIE10DigiSubdet"    ); 
-  iEvent.put( depth         , "QIE10DigiDepth"     ); 
-  iEvent.put( rawId         , "QIE10DigiRawID"     );
-  iEvent.put( linkEr        , "QIE10DigiLinkError" );
-  iEvent.put( flags         , "QIE10DigiFlags"     );
-  iEvent.put( soi           , "QIE10DigiSOI"       );
-  iEvent.put( ok            , "QIE10DigiOK"        );
-  iEvent.put( adc           , "QIE10DigiADC"       );
-  iEvent.put( fc            , "QIE10DigiFC"        );
-  iEvent.put( le_tdc        , "QIE10DigiLETDC"     );
-  iEvent.put( te_tdc        , "QIE10DigiTETDC"     );
-  iEvent.put( capid         , "QIE10DigiCapID"     ); 
+  iEvent.put(move( ieta  )        , "QIE10DigiIEta"      );
+  iEvent.put(move( iphi  )        , "QIE10DigiIPhi"      );
+  iEvent.put(move( subdet)        , "QIE10DigiSubdet"    );
+  iEvent.put(move( depth )        , "QIE10DigiDepth"     );
+  iEvent.put(move( rawId )        , "QIE10DigiRawID"     );
+  iEvent.put(move( linkEr)        , "QIE10DigiLinkError" );
+  iEvent.put(move( flags )        , "QIE10DigiFlags"     );
+  iEvent.put(move( soi   )        , "QIE10DigiSOI"       );
+  iEvent.put(move( ok    )        , "QIE10DigiOK"        );
+  iEvent.put(move( adc   )        , "QIE10DigiADC"       );
+  iEvent.put(move( fc    )        , "QIE10DigiFC"        );
+  iEvent.put(move( le_tdc)        , "QIE10DigiLETDC"     );
+  iEvent.put(move( te_tdc)        , "QIE10DigiTETDC"     );
+  iEvent.put(move( capid )        , "QIE10DigiCapID"     );
 
 }

--- a/plugins/HcalTupleMaker_QIE11Digis.cc
+++ b/plugins/HcalTupleMaker_QIE11Digis.cc
@@ -106,26 +106,26 @@ HcalTupleMaker_QIE11Digis::HcalTupleMaker_QIE11Digis(const edm::ParameterSet& iC
 
 void HcalTupleMaker_QIE11Digis::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-  std::auto_ptr<std::vector<int> >                    ieta   ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    iphi   ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    subdet ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    depth  ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    ieta   ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    iphi   ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    subdet ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    depth  ( new std::vector<int>   ());
 
-  std::auto_ptr<std::vector<int> >                    iRM   ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    iRMFib   ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    iFibCh   ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    iRM   ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    iRMFib   ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    iFibCh   ( new std::vector<int>   ());
 
-  std::auto_ptr<std::vector<int> >                    rawId  ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    linkEr ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    capidEr ( new std::vector<int>   ());
-  std::auto_ptr<std::vector<int> >                    flags  ( new std::vector<int>   ());
-  // std::auto_ptr<int>                                  lasertype (new int() );
-  std::auto_ptr<std::vector<std::vector<int  > > >    soi    ( new std::vector<std::vector<int  > >   ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    ok     ( new std::vector<std::vector<int  > >   ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    adc    ( new std::vector<std::vector<int  > >    ());
-  std::auto_ptr<std::vector<std::vector<double  > > > fc     ( new std::vector<std::vector<double  > > ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    tdc ( new std::vector<std::vector<int  > >    ());
-  std::auto_ptr<std::vector<std::vector<int  > > >    capid  ( new std::vector<std::vector<int  > >    ());
+  std::unique_ptr<std::vector<int> >                    rawId  ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    linkEr ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    capidEr ( new std::vector<int>   ());
+  std::unique_ptr<std::vector<int> >                    flags  ( new std::vector<int>   ());
+  // std::unique_ptr<int>                                  lasertype (new int() );
+  std::unique_ptr<std::vector<std::vector<int  > > >    soi    ( new std::vector<std::vector<int  > >   ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    ok     ( new std::vector<std::vector<int  > >   ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    adc    ( new std::vector<std::vector<int  > >    ());
+  std::unique_ptr<std::vector<std::vector<double  > > > fc     ( new std::vector<std::vector<double  > > ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    tdc ( new std::vector<std::vector<int  > >    ());
+  std::unique_ptr<std::vector<std::vector<int  > > >    capid  ( new std::vector<std::vector<int  > >    ());
     
   //
   bool use_event=true;
@@ -149,13 +149,13 @@ void HcalTupleMaker_QIE11Digis::produce(edm::Event& iEvent, const edm::EventSetu
 	std::cout << "Could not find uMNio " << _taguMNio<< std::endl;
 	use_event = false;
       }
-      std::auto_ptr<int> lasertype (new int(cumnio -> valueUserWord(0)));
-      iEvent.put( lasertype          , "laserType"      ); 
+      std::unique_ptr<int> lasertype (new int(cumnio -> valueUserWord(0)));
+      iEvent.put(move( lasertype )         , "laserType"      );
       //std::cout << "Laser type is " << lasertype<<std::endl;
     }
     else{
-      std::auto_ptr<int> lasertype (new int());
-      iEvent.put( lasertype          , "laserType"      ); 
+      std::unique_ptr<int> lasertype (new int());
+      iEvent.put(move( lasertype )         , "laserType"      );
     }
     //
 
@@ -241,24 +241,24 @@ void HcalTupleMaker_QIE11Digis::produce(edm::Event& iEvent, const edm::EventSetu
     }
 
     //  
-    iEvent.put( ieta          , "QIE11DigiIEta"      ); 
-    iEvent.put( iphi          , "QIE11DigiIPhi"      ); 
-    iEvent.put( subdet        , "QIE11DigiSubdet"    ); 
-    iEvent.put( depth         , "QIE11DigiDepth"     ); 
+    iEvent.put(move( ieta  )        , "QIE11DigiIEta"      );
+    iEvent.put(move( iphi  )        , "QIE11DigiIPhi"      );
+    iEvent.put(move( subdet)        , "QIE11DigiSubdet"    );
+    iEvent.put(move( depth )        , "QIE11DigiDepth"     );
 
-    iEvent.put( iRM           , "QIE11DigiRM"        );
-    iEvent.put( iRMFib        , "QIE11DigiRMFib"     );
-    iEvent.put( iFibCh        , "QIE11DigiFibCh"     );
+    iEvent.put(move( iRM   )        , "QIE11DigiRM"        );
+    iEvent.put(move( iRMFib)        , "QIE11DigiRMFib"     );
+    iEvent.put(move( iFibCh)        , "QIE11DigiFibCh"     );
 
-    iEvent.put( rawId         , "QIE11DigiRawID"     );
-    iEvent.put( linkEr        , "QIE11DigiLinkError" );
-    iEvent.put( capidEr       , "QIE11DigiCapIDError");
-    iEvent.put( flags         , "QIE11DigiFlags"     );
-    iEvent.put( soi           , "QIE11DigiSOI"       );
-    iEvent.put( ok            , "QIE11DigiOK"        );
-    iEvent.put( adc           , "QIE11DigiADC"       );
-    iEvent.put( fc            , "QIE11DigiFC"        );
-    iEvent.put( tdc        , "QIE11DigiTDC"     );
-    iEvent.put( capid         , "QIE11DigiCapID"     ); 
+    iEvent.put(move( rawId  )       , "QIE11DigiRawID"     );
+    iEvent.put(move( linkEr )       , "QIE11DigiLinkError" );
+    iEvent.put(move( capidEr)       , "QIE11DigiCapIDError");
+    iEvent.put(move( flags  )       , "QIE11DigiFlags"     );
+    iEvent.put(move( soi    )       , "QIE11DigiSOI"       );
+    iEvent.put(move( ok     )       , "QIE11DigiOK"        );
+    iEvent.put(move( adc    )       , "QIE11DigiADC"       );
+    iEvent.put(move( fc     )       , "QIE11DigiFC"        );
+    iEvent.put(move( tdc    )       , "QIE11DigiTDC"       );
+    iEvent.put(move( capid  )       , "QIE11DigiCapID"     );
   }
 }

--- a/plugins/HcalTupleMaker_RecoTracks.cc
+++ b/plugins/HcalTupleMaker_RecoTracks.cc
@@ -19,12 +19,12 @@ HcalTupleMaker_RecoTracks::HcalTupleMaker_RecoTracks(const edm::ParameterSet& iC
 
 void HcalTupleMaker_RecoTracks::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
   
-  std::auto_ptr<std::vector<double> > pt  ( new std::vector<double> () );
-  std::auto_ptr<std::vector<double> > eta ( new std::vector<double> () );
-  std::auto_ptr<std::vector<double> > phi ( new std::vector<double> () );
-  std::auto_ptr<std::vector<double> > d0  ( new std::vector<double> () );
-  std::auto_ptr<std::vector<double> > dz  ( new std::vector<double> () );
-  std::auto_ptr<std::vector<int> > nValidHits  ( new std::vector<int> () );
+  std::unique_ptr<std::vector<double> > pt  ( new std::vector<double> () );
+  std::unique_ptr<std::vector<double> > eta ( new std::vector<double> () );
+  std::unique_ptr<std::vector<double> > phi ( new std::vector<double> () );
+  std::unique_ptr<std::vector<double> > d0  ( new std::vector<double> () );
+  std::unique_ptr<std::vector<double> > dz  ( new std::vector<double> () );
+  std::unique_ptr<std::vector<int> > nValidHits  ( new std::vector<int> () );
   
   edm::Handle<reco::TrackCollection> recoTracks;
   iEvent.getByLabel(inputTag, recoTracks);  
@@ -41,11 +41,11 @@ void HcalTupleMaker_RecoTracks::produce(edm::Event& iEvent, const edm::EventSetu
     nValidHits  -> push_back ( recoTrack -> numberOfValidHits ());
   }
 
-  iEvent.put(pt  , prefix + "Pt"  + suffix );
-  iEvent.put(eta , prefix + "Eta" + suffix );
-  iEvent.put(phi , prefix + "Phi" + suffix );
-  iEvent.put(d0  , prefix + "D0"  + suffix );
-  iEvent.put(dz  , prefix + "DZ"  + suffix );
-  iEvent.put(nValidHits , prefix + "NValidHits" + suffix );
+  iEvent.put(move(pt  ), prefix + "Pt"  + suffix );
+  iEvent.put(move(eta ), prefix + "Eta" + suffix );
+  iEvent.put(move(phi ), prefix + "Phi" + suffix );
+  iEvent.put(move(d0  ), prefix + "D0"  + suffix );
+  iEvent.put(move(dz  ), prefix + "DZ"  + suffix );
+  iEvent.put(move(nValidHits), prefix + "NValidHits" + suffix );
   
 }

--- a/plugins/HcalTupleMaker_Tree.cc
+++ b/plugins/HcalTupleMaker_Tree.cc
@@ -86,7 +86,7 @@ HcalTupleMaker_Tree::HcalTupleMaker_Tree(const edm::ParameterSet& iConfig) {
   leafmap["String"]     = STRING;     leafmap["Strings"]    = STRING_V;
 
   edm::Service<edm::ConstProductRegistry> reg;
-  edm::SelectedProducts allBranches = reg->allBranchDescriptions();
+  std::vector< edm::BranchDescription const * > allBranches = reg->allBranchDescriptions();
   //edm::ProductSelectorRules productSelectorRules_(pset, "outputCommands", "HcalTupleMaker_Tree");
   edm::ProductSelectorRules productSelectorRules_(iConfig, "outputCommands", "HcalTupleMaker_Tree");
   edm::ProductSelector productSelector_;
@@ -94,7 +94,7 @@ HcalTupleMaker_Tree::HcalTupleMaker_Tree(const edm::ParameterSet& iConfig) {
 
   std::set<std::string> branchnames;
 
-  BOOST_FOREACH( const edm::SelectedProducts::value_type& selection, allBranches) {
+  for ( auto selection : allBranches ) {
     if(productSelector_.selected(*selection)) {
 
       //Check for duplicate branch names

--- a/plugins/HcalTupleMaker_Trigger.cc
+++ b/plugins/HcalTupleMaker_Trigger.cc
@@ -104,22 +104,22 @@ beginRun(edm::Run& iRun, const edm::EventSetup& iSetup) {
 void HcalTupleMaker_Trigger::
 produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-  std::auto_ptr<std::vector<int> >  l1physbits   ( new std::vector<int>() );
-  std::auto_ptr<std::vector<int> >  l1techbits   ( new std::vector<int>() );
-  std::auto_ptr<std::vector<int> >  hltbits      ( new std::vector<int>() );
+  std::unique_ptr<std::vector<int> >  l1physbits   ( new std::vector<int>() );
+  std::unique_ptr<std::vector<int> >  l1techbits   ( new std::vector<int>() );
+  std::unique_ptr<std::vector<int> >  hltbits      ( new std::vector<int>() );
 
-  std::auto_ptr<std::vector < std::string > > v_hlt_insideDataset_names             (new std::vector<std::string>  ());
-  std::auto_ptr<std::vector < std::string > > v_hlt_outsideDataset_names            (new std::vector<std::string>  ());
-  std::auto_ptr<std::vector < bool > >        v_hlt_insideDataset_decisions         (new std::vector<bool>         ());
-  std::auto_ptr<std::vector < bool > >        v_hlt_outsideDataset_decisions        (new std::vector<bool>         ());
-  std::auto_ptr<std::vector < int > >         v_hlt_insideDataset_prescales         (new std::vector<int>          ());
-  std::auto_ptr<std::vector < int > >         v_hlt_outsideDataset_prescales        (new std::vector<int>          ());
+  std::unique_ptr<std::vector < std::string > > v_hlt_insideDataset_names             (new std::vector<std::string>  ());
+  std::unique_ptr<std::vector < std::string > > v_hlt_outsideDataset_names            (new std::vector<std::string>  ());
+  std::unique_ptr<std::vector < bool > >        v_hlt_insideDataset_decisions         (new std::vector<bool>         ());
+  std::unique_ptr<std::vector < bool > >        v_hlt_outsideDataset_decisions        (new std::vector<bool>         ());
+  std::unique_ptr<std::vector < int > >         v_hlt_insideDataset_prescales         (new std::vector<int>          ());
+  std::unique_ptr<std::vector < int > >         v_hlt_outsideDataset_prescales        (new std::vector<int>          ());
 
   /*
-  std::auto_ptr<std::map<std::string,bool > > m_hlt_insideDataset_namesToDecisions  (new std::map<std::string,bool>());
-  std::auto_ptr<std::map<std::string,bool > > m_hlt_outsideDataset_namesToDecisions (new std::map<std::string,bool>());
-  std::auto_ptr<std::map<std::string,int  > > m_hlt_insideDataset_namesToPrescales  (new std::map<std::string,int >());
-  std::auto_ptr<std::map<std::string,int  > > m_hlt_outsideDataset_namesToPrescales (new std::map<std::string,int >());
+  std::unique_ptr<std::map<std::string,bool > > m_hlt_insideDataset_namesToDecisions  (new std::map<std::string,bool>());
+  std::unique_ptr<std::map<std::string,bool > > m_hlt_outsideDataset_namesToDecisions (new std::map<std::string,bool>());
+  std::unique_ptr<std::map<std::string,int  > > m_hlt_insideDataset_namesToPrescales  (new std::map<std::string,int >());
+  std::unique_ptr<std::map<std::string,int  > > m_hlt_outsideDataset_namesToPrescales (new std::map<std::string,int >());
   */
 
   //-----------------------------------------------------------------
@@ -182,18 +182,18 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // put vectors in the event
   //-----------------------------------------------------------------
 
-  iEvent.put( l1physbits, "L1PhysBits" );
-  iEvent.put( l1techbits, "L1TechBits" );
-  iEvent.put( hltbits,    "HLTBits" );
+  iEvent.put(move( l1physbits ), "L1PhysBits" );
+  iEvent.put(move( l1techbits ), "L1TechBits" );
+  iEvent.put(move( hltbits ),    "HLTBits" );
   
-  iEvent.put( std::auto_ptr<std::string>(new std::string(hltConfig.tableName())), "HLTKey");
+  iEvent.put(move( std::unique_ptr<std::string>(new std::string(hltConfig.tableName()))), "HLTKey");
   
-  iEvent.put ( v_hlt_insideDataset_names      , "HLTInsideDatasetTriggerNames"      ) ;
-  iEvent.put ( v_hlt_outsideDataset_names     , "HLTOutsideDatasetTriggerNames"     ) ;
-  iEvent.put ( v_hlt_insideDataset_decisions  , "HLTInsideDatasetTriggerDecisions"  ) ;
-  iEvent.put ( v_hlt_outsideDataset_decisions , "HLTOutsideDatasetTriggerDecisions" ) ;
-  iEvent.put ( v_hlt_insideDataset_prescales  , "HLTInsideDatasetTriggerPrescales"  ) ;
-  iEvent.put ( v_hlt_outsideDataset_prescales , "HLTOutsideDatasetTriggerPrescales" ) ;
+  iEvent.put ( move(v_hlt_insideDataset_names)      , "HLTInsideDatasetTriggerNames"      ) ;
+  iEvent.put ( move(v_hlt_outsideDataset_names)     , "HLTOutsideDatasetTriggerNames"     ) ;
+  iEvent.put ( move(v_hlt_insideDataset_decisions)  , "HLTInsideDatasetTriggerDecisions"  ) ;
+  iEvent.put ( move(v_hlt_outsideDataset_decisions) , "HLTOutsideDatasetTriggerDecisions" ) ;
+  iEvent.put ( move(v_hlt_insideDataset_prescales)  , "HLTInsideDatasetTriggerPrescales"  ) ;
+  iEvent.put ( move(v_hlt_outsideDataset_prescales) , "HLTOutsideDatasetTriggerPrescales" ) ;
 
   
 }

--- a/plugins/HcalTupleMaker_TriggerObjects.cc
+++ b/plugins/HcalTupleMaker_TriggerObjects.cc
@@ -29,11 +29,11 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Declare items to push into the event
   //------------------------------------------------------------------------
   
-  std::auto_ptr<std::vector < std::string          > > v_filter_names( new std::vector< std::string          > ());
-  std::auto_ptr<std::vector < std::vector< int   > > > v_filter_ids  ( new std::vector< std::vector< int   > > ());
-  std::auto_ptr<std::vector < std::vector< float > > > v_filter_pts  ( new std::vector< std::vector< float > > ());
-  std::auto_ptr<std::vector < std::vector< float > > > v_filter_etas ( new std::vector< std::vector< float > > ());
-  std::auto_ptr<std::vector < std::vector< float > > > v_filter_phis ( new std::vector< std::vector< float > > ());
+  std::unique_ptr<std::vector < std::string          > > v_filter_names( new std::vector< std::string          > ());
+  std::unique_ptr<std::vector < std::vector< int   > > > v_filter_ids  ( new std::vector< std::vector< int   > > ());
+  std::unique_ptr<std::vector < std::vector< float > > > v_filter_pts  ( new std::vector< std::vector< float > > ());
+  std::unique_ptr<std::vector < std::vector< float > > > v_filter_etas ( new std::vector< std::vector< float > > ());
+  std::unique_ptr<std::vector < std::vector< float > > > v_filter_phis ( new std::vector< std::vector< float > > ());
   
   //------------------------------------------------------------------------
   // Get the trigger event and make sure it's valid
@@ -158,11 +158,11 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Push the information into the event
   //------------------------------------------------------------------------
 
-  iEvent.put ( v_filter_names, prefix + "FilterName"    + suffix ) ;
-  iEvent.put ( v_filter_ids  , prefix + "FilterObjId"   + suffix ) ;
-  iEvent.put ( v_filter_pts  , prefix + "FilterObjPt"   + suffix ) ;
-  iEvent.put ( v_filter_etas , prefix + "FilterObjEta"  + suffix ) ;
-  iEvent.put ( v_filter_phis , prefix + "FilterObjPhi"  + suffix ) ;
+  iEvent.put ( move( v_filter_names), prefix + "FilterName"    + suffix ) ;
+  iEvent.put ( move( v_filter_ids ) , prefix + "FilterObjId"   + suffix ) ;
+  iEvent.put ( move( v_filter_pts ) , prefix + "FilterObjPt"   + suffix ) ;
+  iEvent.put ( move( v_filter_etas ), prefix + "FilterObjEta"  + suffix ) ;
+  iEvent.put ( move( v_filter_phis ), prefix + "FilterObjPhi"  + suffix ) ;
 	      
 
 }


### PR DESCRIPTION
These changes are needed to compile under 90X. The primary change is the use of std::unique_ptr rather than the now-deprecated std::auto_ptr. The other changes are that the HBHEHitMapOrganizer now explicitly requires the emap and the edm::BranchDescription syntax has changed.